### PR TITLE
Add frame-src and worker-src, obsolete child-src

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ app.UseCsp(csp =>
         .FromNowhere();
 
     // Contained iframes can be sourced from:
-    csp.AllowChildren
+    csp.AllowFrames
         .FromNowhere(); //Nowhere, no iframes allowed
 
     // Allow AJAX, WebSocket and EventSource connections to:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This library allows you to add Content Security Policy, Strict Transport Security and Public Key Pin headers via middleware.
 
-You can get the library from NuGet: https://www.nuget.org/packages/Joonasw.AspNetCore.SecurityHeaders
+You can get the library from NuGet: [https://www.nuget.org/packages/Joonasw.AspNetCore.SecurityHeaders](https://www.nuget.org/packages/Joonasw.AspNetCore.SecurityHeaders)
 
 ## Example configuration
 
@@ -31,7 +31,7 @@ app.UseCsp(csp =>
     // If nothing is mentioned for a resource class, allow from this domain
     csp.ByDefaultAllow
         .FromSelf();
-    
+
     // Allow JavaScript from:
     csp.AllowScripts
         .FromSelf() //This domain
@@ -82,9 +82,9 @@ app.UseCsp(csp =>
 });
 ```
 
-Content Security Policy can be quite daunting. Here is a nice page to find out what the options do: https://content-security-policy.com/.
+Content Security Policy can be quite daunting. Here is a nice page to find out what the options do: [https://content-security-policy.com/](https://content-security-policy.com/.)
 
-For violation reports, I recommend using Scott Helme's Report URI service at https://report-uri.io/.
+For violation reports, I recommend using Scott Helme's Report URI service at [https://report-uri.io/](https://report-uri.io/).
 
 ## Nonces
 
@@ -134,7 +134,7 @@ csp.AllowStyles
 
 Then to use the nonce tag helper, we need to import it in *_ViewImports.cshtml*:
 
-```
+```c#
 @addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
 ```
 
@@ -154,4 +154,3 @@ Then we just need to use it in the Razor view:
 ```
 
 Now a unique nonce is generated every request and inserted into the CSP header + the elements you want.
-

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
@@ -20,8 +20,9 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
         /// </summary>
         public CspDefaultBuilder ByDefaultAllow { get; } = new CspDefaultBuilder();
         /// <summary>
-        /// Set up rules for embedded content in e.g. iframes.
+        /// Set up rules for embedded content in e.g. iframes.  This has been dropped from web standards and replaced with specific rules for frames and workers
         /// </summary>
+        [Obsolete("Has been replaced with AllowFrames and AllowWorkers")]
         public CspChildBuilder AllowChildren { get; } = new CspChildBuilder();
         /// <summary>
         /// Set up rules for images.
@@ -49,10 +50,17 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
         /// </summary>
         public CspFrameAncestorsBuilder AllowFraming { get; } = new CspFrameAncestorsBuilder();
         /// <summary>
+        /// Set up rules for frames and iframes.
+        /// </summary>
+        public CspFrameBuilder AllowFrames { get; } = new CspFrameBuilder();
+        /// <summary>
         /// Set up rules for plugins in e.g. &lt;object&gt; elements.
         /// </summary>
         public CspPluginBuilder AllowPlugins { get; } = new CspPluginBuilder();
-        
+        /// <summary>
+        /// Set up rules for workers, shared workers and service workers.
+        /// </summary>
+        public CspWorkerBuilder AllowWorkers { get; } = new CspWorkerBuilder();
         /// <summary>
         /// Enables sandboxing of the app in the browser.
         /// </summary>
@@ -111,6 +119,8 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
             _options.Object = pluginOptions.Item1;
             _options.PluginTypes = pluginOptions.Item2;
             _options.Sandbox = _sandboxBuilder.BuildOptions();
+            _options.Frame = AllowFrames.BuildOptions();
+            _options.Worker = AllowWorkers.BuildOptions();
             return _options;
         }
     }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspFrameBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspFrameBuilder.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
+{
+    /// <summary>
+    /// Builder for Content Security Policy rules
+    /// related to &lt;frame&gt; and &lt;iframe&gt; sources.
+    /// </summary>
+    public class CspFrameBuilder
+    {
+        private readonly CspFrameSrcOptions _options = new CspFrameSrcOptions();
+
+        /// <summary>
+        /// Block all &lt;frame&gt;
+        /// and &lt;iframe&gt; sources.
+        /// </summary>
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <summary>
+        /// Allow &lt;frame&gt; and &lt;iframe&gt; sources
+        /// from current domain.
+        /// </summary>
+        /// <returns>The builder for call chaining</returns>
+        public CspFrameBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Allow &lt;frame&gt; and &lt;iframe&gt; sources
+        /// from the given <paramref name="uri"/>.
+        /// </summary>
+        /// <param name="uri">The URI to allow.</param>
+        /// <returns>The builder for call chaining</returns>
+        public CspFrameBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedSources.Add(uri);
+            return this;
+        }
+
+        /// <summary>
+        /// Allow &lt;frame&gt; and &lt;iframe&gt; sources
+        /// from anywhere, except data:, blob:,
+        /// and filesystem: schemes.
+        /// </summary>
+        /// <returns>The builder for call chaining</returns>
+        public CspFrameBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Allow &lt;frame&gt; and &lt;iframe&gt; sources
+        /// only over secure connections.
+        /// </summary>
+        /// <returns>The builder for call chaining</returns>
+        public CspFrameBuilder OnlyOverHttps()
+        {
+            _options.AllowOnlyHttps = true;
+            return this;
+        }
+
+        public CspFrameSrcOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspWorkerBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspWorkerBuilder.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
+{
+    /// <summary>
+    /// Builder for Content Security Policy rules
+    /// related to Worker, SharedWorker and ServiceWorker script sources.
+    /// </summary>
+    public class CspWorkerBuilder
+    {
+        private readonly CspWorkerSrcOptions _options = new CspWorkerSrcOptions();
+
+        /// <summary>
+        /// Block all Worker, SharedWorker or ServiceWorker sources.
+        /// </summary>
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <summary>
+        /// Allow Worker, SharedWorker or ServiceWorker sources
+        /// from current domain.
+        /// </summary>
+        /// <returns>The builder for call chaining</returns>
+        public CspWorkerBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Allow Worker, SharedWorker or ServiceWorker sources
+        /// from the given <paramref name="uri"/>.
+        /// </summary>
+        /// <param name="uri">The URI to allow.</param>
+        /// <returns>The builder for call chaining</returns>
+        public CspWorkerBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedSources.Add(uri);
+            return this;
+        }
+
+        /// <summary>
+        /// Allow Worker, SharedWorker or ServiceWorker sources
+        /// from anywhere, except data:, blob:,
+        /// and filesystem: schemes.
+        /// </summary>
+        /// <returns>The builder for call chaining</returns>
+        public CspWorkerBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Allow Worker, SharedWorker or ServiceWorker sources
+        /// only over secure connections.
+        /// </summary>
+        /// <returns>The builder for call chaining</returns>
+        public CspWorkerBuilder OnlyOverHttps()
+        {
+            _options.AllowOnlyHttps = true;
+            return this;
+        }
+
+        public CspWorkerSrcOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Options/CspFrameSrcOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Options/CspFrameSrcOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Options
+{
+    public class CspFrameSrcOptions : CspSrcOptionsBase
+    {
+        public CspFrameSrcOptions()
+            : base("frame-src")
+        {
+            
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Options/CspWorkerSrcOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Options/CspWorkerSrcOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Options
+{
+    public class CspWorkerSrcOptions : CspSrcOptionsBase
+    {
+        public CspWorkerSrcOptions()
+            : base("worker-src")
+        {
+            
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
@@ -27,7 +27,9 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         public CspDefaultSrcOptions Default { get; set; }
         /// <summary>
         /// Rules to apply for web workers and nested frames.
+        /// This has been removed from web standards and replaced with specific rules for frames and workers
         /// </summary>
+        [Obsolete("Replaced with Frame and Worker")]
         public CspChildSrcOptions Child { get; set; }
         /// <summary>
         /// Rules to apply for AJAX, WebSockets and EventSource.
@@ -61,10 +63,18 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         /// </summary>
         public CspFrameAncestorsOptions FrameAncestors { get; set; }
         /// <summary>
+        /// Rules to apply for related to &lt;frame&gt; and &lt;iframe&gt; sources.
+        /// </summary>
+        public CspFrameSrcOptions Frame { get; set; }
+        /// <summary>
         /// Rules for what MIME types are allowed for plugins,
         /// e.g. in &lt;object&gt; elements.
         /// </summary>
         public CspPluginTypesOptions PluginTypes { get; set; }
+        /// <summary>
+        /// Rules to apply for related to Worker, SharedWorker and ServiceWorker script sources.
+        /// </summary>
+        public CspWorkerSrcOptions Worker { get; set; }
         /// <summary>
         /// If true, the browser will execute the page in a
         /// tightly controlled sandbox.
@@ -116,6 +126,8 @@ namespace Joonasw.AspNetCore.SecurityHeaders
             FrameAncestors = new CspFrameAncestorsOptions();
             PluginTypes = new CspPluginTypesOptions();
             Sandbox = new CspSandboxOptions();
+            Frame = new CspFrameSrcOptions();
+            Worker = new CspWorkerSrcOptions();
         }
 
         public (string headerName, string headerValue) ToString(ICspNonceService nonceService)
@@ -142,7 +154,9 @@ namespace Joonasw.AspNetCore.SecurityHeaders
                 Media.ToString(nonceService),
                 Object.ToString(nonceService),
                 FrameAncestors.ToString(),
-                PluginTypes.ToString()
+                PluginTypes.ToString(),
+                Frame.ToString(nonceService),
+                Worker.ToString(nonceService)
             };
             if (BlockAllMixedContent)
             {

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
@@ -77,5 +77,18 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Tests
 
             Assert.True(options.BlockAllMixedContent);
         }
+
+        [Fact]
+        public void WithFramesAndWorkers_ReturnsCorrectHeader()
+        {
+            var builder = new CspBuilder();
+
+            builder.AllowFrames.From("https://www.google.com");
+            builder.AllowWorkers.FromSelf().OnlyOverHttps();
+
+            var headerValue = builder.BuildCspOptions().ToString(null).headerValue;
+
+            Assert.Equal("frame-src https://www.google.com;worker-src 'self' https:", headerValue);
+        }
     }
 }

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspOptionsTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspOptionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
 using Xunit;
 
 namespace Joonasw.AspNetCore.SecurityHeaders.Tests
@@ -69,6 +70,27 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Tests
 
             Assert.Equal("Content-Security-Policy", headerName);
             Assert.Equal("default-src 'self';script-src userscripts.example.com;img-src *;media-src media1.com media2.com", headerValue);
+        }
+
+        [Fact]
+        public void WorkerAndFrameOptions_ResultIsCorrect()
+        {
+            var options = new CspOptions
+            {
+                Frame = new CspFrameSrcOptions
+                {
+                    AllowAny = true
+                },
+                Worker = new CspWorkerSrcOptions
+                {
+                    AllowSelf = true
+                }
+            };
+
+            var (headerName, headerValue) = options.ToString(null);
+
+            Assert.Equal("Content-Security-Policy", headerName);
+            Assert.Equal("frame-src *;worker-src 'self'", headerValue);
         }
 
         [Fact]

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspWorkerBuilderTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspWorkerBuilderTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using Joonasw.AspNetCore.SecurityHeaders.Csp.Builder;
+using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
+using Xunit;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.Tests
+{
+    public class CspWorkerBuilderTests
+    {
+        [Fact]
+        public void FromNowhere_SetsAllowNoneToTrue()
+        {
+            var builder = new CspWorkerBuilder();
+
+            builder.FromNowhere();
+            CspWorkerSrcOptions options = builder.BuildOptions();
+
+            Assert.True(options.AllowNone);
+        }
+
+        [Fact]
+        public void FromSelf_SetsAllowSelfToTrue()
+        {
+            var builder = new CspWorkerBuilder();
+
+            builder.FromSelf();
+            CspWorkerSrcOptions options = builder.BuildOptions();
+
+            Assert.True(options.AllowSelf);
+        }
+
+        [Fact]
+        public void FromSelf_ReturnsCorrectString()
+        {
+            var builder = new CspWorkerBuilder();
+
+            builder.FromSelf();
+            CspWorkerSrcOptions options = builder.BuildOptions();
+
+            Assert.Equal("worker-src 'self'", options.ToString(null));
+        }
+
+        [Fact]
+        public void From_AddsUrlToAllowedSources()
+        {
+            var builder = new CspWorkerBuilder();
+
+            builder.From("www.google.com");
+            CspWorkerSrcOptions options = builder.BuildOptions();
+
+            Assert.Equal("www.google.com", options.AllowedSources.Single());
+        }
+
+        [Fact]
+        public void From_ThrowsArgumentNullException_WithNullUrl()
+        {
+            var builder = new CspWorkerBuilder();
+
+            Assert.Throws<ArgumentNullException>(() => builder.From(null));
+        }
+
+        [Fact]
+        public void From_ThrowsArgumentException_WithEmptyUrl()
+        {
+            var builder = new CspWorkerBuilder();
+
+            Assert.Throws<ArgumentException>(() => builder.From(string.Empty));
+        }
+
+        [Fact]
+        public void FromAnywhere_SetsAllowAnyToTrue()
+        {
+            var builder = new CspWorkerBuilder();
+
+            builder.FromAnywhere();
+            CspWorkerSrcOptions options = builder.BuildOptions();
+
+            Assert.True(options.AllowAny);
+        }
+
+        [Fact]
+        public void OnlyOverHttps_SetsAllowOnlyHttpsToTrue()
+        {
+            var builder = new CspWorkerBuilder();
+
+            builder.OnlyOverHttps();
+            CspWorkerSrcOptions options = builder.BuildOptions();
+
+            Assert.True(options.AllowOnlyHttps);
+        }
+    }
+}


### PR DESCRIPTION
The child-src policy has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src) and replaced with specific policies for [frames](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src) and [workers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src).

This includes new builders for frames and workers and marks the child classes as obsolete.