### PR TITLE
Attempt to solve #12: let application decide when to add the CSP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ app.UseCsp(csp =>
     csp.SetReportOnly();
     // Where should the violation reports be sent to?
     csp.ReportViolationsTo("/csp-report");
+
+    // Do not include the CSP header for requests to the /api endpoints
+    csp.OnSendingHeader = context =>
+    {
+        context.ShouldNotSend = context.HttpContext.Request.Path.StartsWithSegments("/api");
+        return Task.CompletedTask;
+    };
 });
 ```
 

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
 
 namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
@@ -61,6 +62,9 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
         /// Set up rules for workers, shared workers and service workers.
         /// </summary>
         public CspWorkerBuilder AllowWorkers { get; } = new CspWorkerBuilder();
+
+        public Func<CspSendingHeaderContext, Task> OnSendingHeader { get; set; } = context => Task.CompletedTask;
+
         /// <summary>
         /// Enables sandboxing of the app in the browser.
         /// </summary>
@@ -123,6 +127,8 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
             _options.Sandbox = _sandboxBuilder.BuildOptions();
             _options.Frame = AllowFrames.BuildOptions();
             _options.Worker = AllowWorkers.BuildOptions();
+
+            _options.OnSendingHeader = OnSendingHeader;
             return _options;
         }
     }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
@@ -127,7 +127,6 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
             _options.Sandbox = _sandboxBuilder.BuildOptions();
             _options.Frame = AllowFrames.BuildOptions();
             _options.Worker = AllowWorkers.BuildOptions();
-
             _options.OnSendingHeader = OnSendingHeader;
             return _options;
         }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/CspMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/CspMiddleware.cs
@@ -39,20 +39,26 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp
 
         public async Task Invoke(HttpContext context)
         {
-            string headerName;
-            string headerValue;
-            if (_options.IsNonceNeeded)
+            var sendingHeaderContext = new CspSendingHeaderContext(context);
+            await _options.SendingHeader(sendingHeaderContext);
+
+            if (!sendingHeaderContext.ShouldNotSend)
             {
-                var nonceService = (ICspNonceService)context.RequestServices.GetService(typeof(ICspNonceService));
-                (headerName, headerValue) = _options.ToString(nonceService);
-            }
-            else
-            {
-                headerName = _headerName;
-                headerValue = _headerValue;
+                string headerName;
+                string headerValue;
+                if (_options.IsNonceNeeded)
+                {
+                    var nonceService = (ICspNonceService)context.RequestServices.GetService(typeof(ICspNonceService));
+                    (headerName, headerValue) = _options.ToString(nonceService);
+                }
+                else
+                {
+                    headerName = _headerName;
+                    headerValue = _headerValue;
+                }
+                context.Response.Headers.Add(headerName, headerValue);
             }
 
-            context.Response.Headers.Add(headerName, headerValue);
             await _next.Invoke(context);
         }
     }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/CspMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/CspMiddleware.cs
@@ -40,7 +40,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp
         public async Task Invoke(HttpContext context)
         {
             var sendingHeaderContext = new CspSendingHeaderContext(context);
-            await _options.SendingHeader(sendingHeaderContext);
+            await _options.OnSendingHeader(sendingHeaderContext);
 
             if (!sendingHeaderContext.ShouldNotSend)
             {

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/CspSendingHeaderContext.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/CspSendingHeaderContext.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.Csp
+{
+    public class CspSendingHeaderContext
+    {
+        /// <summary>
+        /// The http context.
+        /// </summary>
+        public readonly HttpContext HttpContext;
+
+        /// <summary>
+        /// <c>true</c> iff the CSP header should not be sent, <c>false</c> otherwise.
+        /// </summary>
+        public bool ShouldNotSend { get; set; }
+
+        public CspSendingHeaderContext(HttpContext httpContext)
+        {
+            HttpContext = httpContext;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Joonasw.AspNetCore.SecurityHeaders.Csp;
 using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
 
@@ -112,6 +113,18 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         /// channel.
         /// </summary>
         public bool BlockAllMixedContent { get; set; }
+
+        /// <summary>
+        /// A delegate assigned to this property will be invoked when the related method
+        /// is called.
+        /// </summary>
+        public Func<CspSendingHeaderContext, Task> OnSendingHeader { get; set; } = context => Task.CompletedTask;
+
+        /// <summary>
+        /// Implements the interface method by invoking the related delegate method.
+        /// </summary>
+        /// <param name="context"></param>
+        public virtual Task SendingHeader(CspSendingHeaderContext context) => OnSendingHeader(context);
 
         public CspOptions()
         {

--- a/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
@@ -115,16 +115,11 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         public bool BlockAllMixedContent { get; set; }
 
         /// <summary>
-        /// A delegate assigned to this property will be invoked when the related method
-        /// is called.
+        /// A delegate assigned to this property will be invoked when the <c>CspMiddleware</c> is
+        /// about to send the CSP header.
+        /// The default implementation always sends the CSP header.
         /// </summary>
         public Func<CspSendingHeaderContext, Task> OnSendingHeader { get; set; } = context => Task.CompletedTask;
-
-        /// <summary>
-        /// Implements the interface method by invoking the related delegate method.
-        /// </summary>
-        /// <param name="context"></param>
-        public virtual Task SendingHeader(CspSendingHeaderContext context) => OnSendingHeader(context);
 
         public CspOptions()
         {

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Samples/Startup.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Samples/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
 
 namespace Joonasw.AspNetCore.SecurityHeaders.Samples
 {
@@ -107,6 +108,12 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Samples
             //    csp.SetReportOnly();
             //    csp.ReportViolationsTo("/csp-report");
             //    csp.SetUpgradeInsecureRequests(); //Upgrade HTTP URIs to HTTPS
+
+            //    csp.OnSendingHeader = context =>
+            //    {
+            //        context.ShouldNotSend = context.HttpContext.Request.Path.StartsWithSegments("/api");
+            //        return Task.CompletedTask;
+            //    };
             //});
 
             app.UseMvc(routes =>

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Joonasw.AspNetCore.SecurityHeaders.Csp;
 using Joonasw.AspNetCore.SecurityHeaders.Csp.Builder;
-using Microsoft.AspNetCore.Http;
 using Xunit;
 
 namespace Joonasw.AspNetCore.SecurityHeaders.Tests

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
@@ -104,7 +104,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Tests
             };
 
             var sendingHeaderContext = new CspSendingHeaderContext(null);
-            await builder.BuildCspOptions().SendingHeader(sendingHeaderContext);
+            await builder.BuildCspOptions().OnSendingHeader(sendingHeaderContext);
 
             Assert.Equal(true, sendingHeaderContext.ShouldNotSend);
         }

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Threading.Tasks;
+using Joonasw.AspNetCore.SecurityHeaders.Csp;
 using Joonasw.AspNetCore.SecurityHeaders.Csp.Builder;
+using Microsoft.AspNetCore.Http;
 using Xunit;
 
 namespace Joonasw.AspNetCore.SecurityHeaders.Tests
@@ -88,6 +91,23 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Tests
             var headerValue = builder.BuildCspOptions().ToString(null).headerValue;
 
             Assert.Equal("frame-src https://www.google.com;worker-src 'self' https:", headerValue);
+        }
+
+        [Fact]
+        public async Task OnSendingHeader_ShouldNotSendTest()
+        {
+            var builder = new CspBuilder();
+
+            builder.OnSendingHeader = context =>
+            {
+                context.ShouldNotSend = true;
+                return Task.CompletedTask;
+            };
+
+            var sendingHeaderContext = new CspSendingHeaderContext(null);
+            await builder.BuildCspOptions().SendingHeader(sendingHeaderContext);
+
+            Assert.Equal(true, sendingHeaderContext.ShouldNotSend);
         }
     }
 }


### PR DESCRIPTION
I have omitted the `Events` object and directly added a property `OnSendingHeader` on `CspOptions` as you suggested.

Instead of the `Task<bool>` idea I decided to go with a `CspSendingHeaderContext` which contains the `HttpContext` and a `ShouldNotSend` property. This approach is slightly more backward compatible in case you wanted to add more interaction logic between the application and the `CspMiddleware` in the future instead of returning a simple `bool`. This way, the `OnSendingHeader` signature would not need to change and client applications would not need to update their code when pulling in new releases from your nuget library.

This `OnSendHeader` mechanism also applies to the other two headers `HSTS` and `HPKP`.