### PR TITLE
Add support for new prefetch-src header

### DIFF
--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
@@ -62,12 +62,16 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
         /// Set up rules for workers, shared workers and service workers.
         /// </summary>
         public CspWorkerBuilder AllowWorkers { get; } = new CspWorkerBuilder();
-        /// <summary>
-        /// Set up rules for allowed &lt;base&gt; element sources.
-        /// It is used to control what can be used as the base URI
-        /// for the document.
-        /// </summary>
-        public CspBaseUriBuilder AllowBaseUri { get; } = new CspBaseUriBuilder();
+	    /// <summary>
+	    /// Sets up rules for where this app can pre-fetch/pre-render content from
+	    /// </summary>
+	    public CspPrefetchBuilder AllowPrefetch { get; } = new CspPrefetchBuilder();
+		/// <summary>
+		/// Set up rules for allowed &lt;base&gt; element sources.
+		/// It is used to control what can be used as the base URI
+		/// for the document.
+		/// </summary>
+		public CspBaseUriBuilder AllowBaseUri { get; } = new CspBaseUriBuilder();
 
         public Func<CspSendingHeaderContext, Task> OnSendingHeader { get; set; } = context => Task.CompletedTask;
 
@@ -133,7 +137,8 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
             _options.Sandbox = _sandboxBuilder.BuildOptions();
             _options.Frame = AllowFrames.BuildOptions();
             _options.Worker = AllowWorkers.BuildOptions();
-            _options.BaseUri = AllowBaseUri.BuildOptions();
+	        _options.Prefetch = AllowPrefetch.BuildOptions();
+			_options.BaseUri = AllowBaseUri.BuildOptions();
             _options.OnSendingHeader = OnSendingHeader;
             return _options;
         }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspPrefetchBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspPrefetchBuilder.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
+{
+	/// <summary>
+	/// Builder for Content Security Policy rules
+	/// related to pre-fetching and pre-rendering content
+	/// </summary>
+	public class CspPrefetchBuilder
+	{
+		private readonly CspPrefetchSrcOptions _options = new CspPrefetchSrcOptions();
+
+		/// <summary>
+		/// Block all pre-fetching/pre-rendering
+		/// </summary>
+		public void FromNowhere() 
+		{
+			_options.AllowNone = true;
+		}
+
+		/// <summary>
+		/// Allow pre-fetching/pre-rendering
+		/// from current domain.
+		/// </summary>
+		/// <returns>The builder for call chaining</returns>
+		public CspPrefetchBuilder FromSelf()
+		{
+			_options.AllowSelf = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Allow pre-fetching/pre-rendering
+		/// from the given <paramref name="uri"/>.
+		/// </summary>
+		/// <param name="uri">The URI to allow.</param>
+		/// <returns>The builder for call chaining</returns>
+		public CspPrefetchBuilder From(string uri)
+		{
+			if (uri == null) throw new ArgumentNullException(nameof(uri));
+			if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+			_options.AllowedSources.Add(uri);
+			return this;
+		}
+
+		/// <summary>
+		/// Allow pre-fetching/pre-rendering
+		/// from anywhere, except data:, blob:,
+		/// and filesystem: schemes.
+		/// </summary>
+		/// <returns>The builder for call chaining</returns>
+		public CspPrefetchBuilder FromAnywhere() 
+		{
+			_options.AllowAny = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Allow pre-fetching/pre-rendering
+		/// only over secure connections.
+		/// </summary>
+		/// <returns>The builder for call chaining</returns>
+		public CspPrefetchBuilder OnlyOverHttps()
+		{
+			_options.AllowOnlyHttps = true;
+			return this;
+		}
+
+		public CspPrefetchSrcOptions BuildOptions()
+		{
+			return _options;
+		}
+	}
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Options/CspPrefetchSrcOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Options/CspPrefetchSrcOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Options
+{
+    public class CspPrefetchSrcOptions : CspSrcOptionsBase
+    {
+	    public CspPrefetchSrcOptions()
+		    : base("prefetch-src")
+	    {
+	    }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
@@ -78,13 +78,17 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         /// ServiceWorker script sources.
         /// </summary>
         public CspWorkerSrcOptions Worker { get; set; }
-        /// <summary>
-        /// Restricts the URIs which can be used in a
-        /// document's &lt;base&gt; element, and subsequently
-        /// be the document's base URI.
-        /// If not set, any URL is allowed.
-        /// </summary>
-        public CspBaseUriOptions BaseUri { get; set; }
+		/// <summary>
+	    /// Rules to apply for pre-fetching/pre-rendering content
+	    /// </summary>
+	    public CspPrefetchSrcOptions Prefetch { get; set; }
+		/// <summary>
+		/// Restricts the URIs which can be used in a
+		/// document's &lt;base&gt; element, and subsequently
+		/// be the document's base URI.
+		/// If not set, any URL is allowed.
+		/// </summary>
+		public CspBaseUriOptions BaseUri { get; set; }
         /// <summary>
         /// If true, the browser will execute the page in a
         /// tightly controlled sandbox.
@@ -128,7 +132,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         /// </summary>
         public Func<CspSendingHeaderContext, Task> OnSendingHeader { get; set; }
 
-        public CspOptions()
+	    public CspOptions()
         {
             Script = new CspScriptSrcOptions();
             Style = new CspStyleSrcOptions();
@@ -147,6 +151,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
             Sandbox = new CspSandboxOptions();
             Frame = new CspFrameSrcOptions();
             Worker = new CspWorkerSrcOptions();
+			Prefetch = new CspPrefetchSrcOptions();
             BaseUri = new CspBaseUriOptions();
             OnSendingHeader = context => Task.CompletedTask;
         }
@@ -180,6 +185,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
                 PluginTypes.ToString(),
                 Frame.ToString(nonceService),
                 Worker.ToString(nonceService),
+				Prefetch.ToString(nonceService),
                 BaseUri.ToString(nonceService)
             };
             if (BlockAllMixedContent)

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
@@ -92,6 +92,18 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Tests
             Assert.Equal("frame-src https://www.google.com;worker-src 'self' https:", headerValue);
         }
 
+		[Fact]
+		public void WithPrefetch_ReturnsCorrectHeader()
+		{
+			var builder = new CspBuilder();
+
+			builder.AllowPrefetch.From("https://www.google.com");
+
+			var headerValue = builder.BuildCspOptions().ToString(null).headerValue;
+
+			Assert.Equal("prefetch-src https://www.google.com", headerValue);
+		}
+
         [Fact]
         public async Task OnSendingHeader_ShouldNotSendTest()
         {


### PR DESCRIPTION
See https://w3c.github.io/webappsec-csp/#directive-prefetch-src for details

Whilst this is still only in the draft specification Chrome already supports (and enforces...) this header as of at least version 67. 

The other option, if you don't want to include support for a draft specification, would be to extend the library to allow arbitrary sending of content. A la `CspSendingHeaderContext` extension point.

Resolves #26 .