### PR TITLE
Add support for all security headers

### DIFF
--- a/src/Joonasw.AspNetCore.SecurityHeaders/AppBuilderExtensions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/AppBuilderExtensions.cs
@@ -34,7 +34,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
             var builder = new CspBuilder();
             builderAction(builder);
 
-            var options = builder.BuildCspOptions();
+            CspOptions options = builder.BuildCspOptions();
 
             return app.UseMiddleware<CspMiddleware>(new OptionsWrapper<CspOptions>(options));
         }
@@ -88,7 +88,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         {
             var builder = new HpkpBuilder();
             builderAction(builder);
-            var options = builder.BuildHpkpOptions();
+            HpkpOptions options = builder.BuildHpkpOptions();
             return app.UseMiddleware<HpkpMiddleware>(new OptionsWrapper<HpkpOptions>(options));
         }
 
@@ -196,8 +196,8 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         }
 
         /// <summary>
-        /// Adds a Feature Policy header
-        /// to the response.
+        /// Adds a Feature Policy headerto the response.
+        /// See https://github.com/WICG/feature-policy/blob/master/features.md for more information
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/></param>
         /// <param name="builderAction">Configuration action for the header.</param>
@@ -213,8 +213,8 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         }
 
         /// <summary>
-        /// Adds a Feature Policy header
-        /// to the response.
+        /// Adds a Feature Policy header to the response.
+        /// See https://github.com/WICG/feature-policy/blob/master/features.md for more information
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/></param>
         /// <returns>The <see cref="IApplicationBuilder"/></returns>

--- a/src/Joonasw.AspNetCore.SecurityHeaders/AppBuilderExtensions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/AppBuilderExtensions.cs
@@ -196,7 +196,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         }
 
         /// <summary>
-        /// Adds a Content Security Policy header
+        /// Adds a Feature Policy header
         /// to the response.
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/></param>
@@ -213,7 +213,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         }
 
         /// <summary>
-        /// Adds a Content Security Policy header
+        /// Adds a Feature Policy header
         /// to the response.
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/></param>

--- a/src/Joonasw.AspNetCore.SecurityHeaders/AppBuilderExtensions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/AppBuilderExtensions.cs
@@ -1,9 +1,16 @@
 ﻿using System;
 using Joonasw.AspNetCore.SecurityHeaders.Csp;
 using Joonasw.AspNetCore.SecurityHeaders.Csp.Builder;
+using Joonasw.AspNetCore.SecurityHeaders.ExpectCT;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder;
 using Joonasw.AspNetCore.SecurityHeaders.Hpkp;
 using Joonasw.AspNetCore.SecurityHeaders.Hpkp.Builder;
 using Joonasw.AspNetCore.SecurityHeaders.Hsts;
+using Joonasw.AspNetCore.SecurityHeaders.ReferrerPolicy;
+using Joonasw.AspNetCore.SecurityHeaders.XContentTypeOptions;
+using Joonasw.AspNetCore.SecurityHeaders.XFrameOptions;
+using Joonasw.AspNetCore.SecurityHeaders.XXssProtection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Options;
 
@@ -27,7 +34,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
             var builder = new CspBuilder();
             builderAction(builder);
 
-            CspOptions options = builder.BuildCspOptions();
+            var options = builder.BuildCspOptions();
 
             return app.UseMiddleware<CspMiddleware>(new OptionsWrapper<CspOptions>(options));
         }
@@ -81,7 +88,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         {
             var builder = new HpkpBuilder();
             builderAction(builder);
-            HpkpOptions options = builder.BuildHpkpOptions();
+            var options = builder.BuildHpkpOptions();
             return app.UseMiddleware<HpkpMiddleware>(new OptionsWrapper<HpkpOptions>(options));
         }
 
@@ -94,6 +101,149 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         public static IApplicationBuilder UseHpkp(this IApplicationBuilder app)
         {
             return app.UseMiddleware<HpkpMiddleware>();
+        }
+
+        /// <summary>
+        /// Sets the X-Frame-Options header to DENY by default
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseXFrameOptions(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<XFrameOptionsMiddleware>();
+        }
+
+        /// <summary>
+        /// Sets the X-Frame-Options header
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseXFrameOptions(
+            this IApplicationBuilder app,
+            XFrameOptionsOptions options)
+        {
+            return app.UseMiddleware<XFrameOptionsMiddleware>(new OptionsWrapper<XFrameOptionsOptions>(options));
+        }
+
+        /// <summary>
+        /// Sets the X-Xss-Protection header to enable AND block by default
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseXXssProtection(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<XXssProtectionMiddleware>();
+        }
+
+        /// <summary>
+        /// Sets the  X-Xss-Protection header
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseXXssProtection(
+            this IApplicationBuilder app,
+            XXssProtectionOptions options)
+        {
+            return app.UseMiddleware<XXssProtectionMiddleware>(new OptionsWrapper<XXssProtectionOptions>(options));
+        }
+
+        /// <summary>
+        /// Sets the X-Content-Type-Options header to nosniff by default
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseXContentTypeOptions(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<XContentTypeOptionsMiddleware>();
+        }
+
+        /// <summary>
+        /// Sets the X-Content-Type-Options header
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseXContentTypeOptions(
+            this IApplicationBuilder app,
+            XContentTypeOptionsOptions options)
+        {
+            return app.UseMiddleware<XContentTypeOptionsMiddleware>(new OptionsWrapper<XContentTypeOptionsOptions>(options));
+        }
+
+        /// <summary>
+        /// Sets the Referrer Policy header to no-referrer by default
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseReferrerPolicy(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<ReferrerPolicyMiddleware>();
+        }
+
+        /// <summary>
+        /// Sets the Referrer Policy header
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseReferrerPolicy(
+            this IApplicationBuilder app,
+            ReferrerPolicyOptions options)
+        {
+            return app.UseMiddleware<ReferrerPolicyMiddleware>(new OptionsWrapper<ReferrerPolicyOptions>(options));
+        }
+
+        /// <summary>
+        /// Adds a Content Security Policy header
+        /// to the response.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <param name="builderAction">Configuration action for the header.</param>
+        /// <returns>The <see cref="IApplicationBuilder"/></returns>
+        public static IApplicationBuilder UseFeaturePolicy(this IApplicationBuilder app, Action<FeaturePolicyBuilder> builderAction)
+        {
+            var builder = new FeaturePolicyBuilder();
+            builderAction(builder);
+
+            var options = builder.BuildFeaturePolicyOptions();
+
+            return app.UseMiddleware<FeaturePolicyMiddleware>(new OptionsWrapper<FeaturePolicyOptions>(options));
+        }
+
+        /// <summary>
+        /// Adds a Content Security Policy header
+        /// to the response.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <returns>The <see cref="IApplicationBuilder"/></returns>
+        public static IApplicationBuilder UseFeaturePolicy(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<FeaturePolicyMiddleware>();
+        }
+
+        /// <summary>
+        /// Adds a Expect-CT Header to the response. (NOT YET SUPPORTED)
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <param name="options"></param>
+        /// <returns>The <see cref="IApplicationBuilder"/></returns>
+        public static IApplicationBuilder UseExpectCT(
+            this IApplicationBuilder app,
+            ExpectCTOptions options)
+        {
+            return app.UseMiddleware<ExpectCTMiddleware>(new OptionsWrapper<ExpectCTOptions>(options));
+        }
+
+        /// <summary>
+        /// Adds a Expect-CT header to the response.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/></param>
+        /// <returns>The <see cref="IApplicationBuilder"/></returns>
+        public static IApplicationBuilder UseExpectCT(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<ExpectCTMiddleware>();
         }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/CspOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/CspOptions.cs
@@ -2,10 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Joonasw.AspNetCore.SecurityHeaders.Csp;
 using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
 
-namespace Joonasw.AspNetCore.SecurityHeaders
+namespace Joonasw.AspNetCore.SecurityHeaders.Csp
 {
     public class CspOptions
     {

--- a/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
@@ -2,9 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Joonasw.AspNetCore.SecurityHeaders.Csp;
 using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
 
-namespace Joonasw.AspNetCore.SecurityHeaders.Csp
+namespace Joonasw.AspNetCore.SecurityHeaders
 {
     public class CspOptions
     {

--- a/src/Joonasw.AspNetCore.SecurityHeaders/ExpectCT/ExpectCTMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/ExpectCT/ExpectCTMiddleware.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -19,11 +21,16 @@ namespace Joonasw.AspNetCore.SecurityHeaders.ExpectCT
         public async Task Invoke(HttpContext context)
         {
             //Expect-CT can only be applied to secure requests according to spec
-            if (context.Request.IsHttps)
+            if (context.Request.IsHttps && !ContainsExpectCTHeader(context.Response))
             {
                 context.Response.Headers.Add(HeaderName, _headerValue);
             }
             await _next(context);
+        }
+
+        private static bool ContainsExpectCTHeader(HttpResponse response)
+        {
+            return response.Headers.Any(h => h.Key.Equals(HeaderName, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/ExpectCT/ExpectCTMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/ExpectCT/ExpectCTMiddleware.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.ExpectCT
+{
+    public class ExpectCTMiddleware
+    {
+        private const string HeaderName = "Expect-CT";
+        private readonly RequestDelegate _next;
+        private readonly string _headerValue;
+
+        public ExpectCTMiddleware(RequestDelegate next, IOptions<ExpectCTOptions> options)
+        {
+            _next = next;
+            _headerValue = options.Value.HeaderValue;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            //Expect-CT can only be applied to secure requests according to spec
+            if (context.Request.IsHttps)
+            {
+                context.Response.Headers.Add(HeaderName, _headerValue);
+            }
+            await _next(context);
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/ExpectCT/ExpectCTOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/ExpectCT/ExpectCTOptions.cs
@@ -1,0 +1,75 @@
+﻿using System;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.ExpectCT
+{
+    /// <summary>
+    /// Options for the Expect-CT Header
+    /// </summary>
+    public class ExpectCTOptions
+    {
+        public ExpectCTOptions()
+        {
+            
+        }
+
+        /// <summary>
+        /// Defines the parameters for the Expect-CT header sent to clients.
+        /// NOT CURRENTLY SUPPORTED
+        /// </summary>
+        /// <param name="maxAge">The required max-age directive specifies the number of seconds that the browser should cache and apply the received policy for, whether enforced or report-only.</param>
+        /// <param name="reportUri">the report-uri directive specifies where the browser should send reports if it does not receive valid CT information. This is specified as an absolute URI.</param>
+        /// <param name="enforce">The optional enforce directive controls whether the browser should enforce the policy or treat it as report-only mode. The directive has no value so you simply include it or not depending on whether or not you want the browser to enforce the policy or just report on it.</param>
+        public ExpectCTOptions(TimeSpan maxAge, string reportUri, bool enforce = false)
+        {
+            MaxAge = maxAge;
+            Enforce = enforce;
+            ReportUri = reportUri;
+        }
+
+        /// <summary>
+        /// Gets the maxAge browsers should remember that
+        /// this domain should only be accessed over HTTPS.
+        /// </summary>
+        public TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(30);
+
+        /// <summary>
+        /// Gets the maxAge browsers should remember
+        /// this domain should only be accessed over HTTPS,
+        /// in seconds.
+        /// </summary>
+        public int DurationSeconds => (int)MaxAge.TotalSeconds;
+
+        /// <summary>
+        /// Gets if this rule should apply to the current host.
+        /// </summary>
+        public bool Enforce { get; set; }
+
+        /// <summary>
+        /// Gets if this domain should be allowed to be
+        /// added to preload lists in browsers.
+        /// </summary>
+        public string ReportUri { get; set; }
+
+        public string HeaderValue
+        {
+            get
+            {
+                var value = string.Empty;
+
+                if (Enforce)
+                {
+                    value += "enforce";
+                }
+
+                value += ";" + "max-age=" + DurationSeconds;
+
+                if (ReportUri != null)
+                {
+                    value += "; report-uri=\"" + ReportUri + "\"";
+                }
+
+                return value;
+            }
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/ExpectCT/ExpectCTOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/ExpectCT/ExpectCTOptions.cs
@@ -16,9 +16,14 @@ namespace Joonasw.AspNetCore.SecurityHeaders.ExpectCT
         /// Defines the parameters for the Expect-CT header sent to clients.
         /// NOT CURRENTLY SUPPORTED
         /// </summary>
-        /// <param name="maxAge">The required max-age directive specifies the number of seconds that the browser should cache and apply the received policy for, whether enforced or report-only.</param>
-        /// <param name="reportUri">the report-uri directive specifies where the browser should send reports if it does not receive valid CT information. This is specified as an absolute URI.</param>
-        /// <param name="enforce">The optional enforce directive controls whether the browser should enforce the policy or treat it as report-only mode. The directive has no value so you simply include it or not depending on whether or not you want the browser to enforce the policy or just report on it.</param>
+        /// <param name="maxAge">The required max-age directive specifies the number of seconds that
+        /// the browser should cache and apply the received policy for, whether enforced or report-only.</param>
+        /// <param name="reportUri">the report-uri directive specifies where the browser should send reports
+        /// if it does not receive valid CT information. This is specified as an absolute URI.</param>
+        /// <param name="enforce">The optional enforce directive controls whether the browser should
+        /// enforce the policy or treat it as report-only mode. The directive has no value so you simply
+        /// include it or not depending on whether or not you want the browser to enforce the policy
+        /// or just report on it.</param>
         public ExpectCTOptions(TimeSpan maxAge, string reportUri, bool enforce = false)
         {
             MaxAge = maxAge;
@@ -61,7 +66,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders.ExpectCT
                     value += "enforce";
                 }
 
-                value += ";" + "max-age=" + DurationSeconds;
+                value += "; " + "max-age=" + DurationSeconds;
 
                 if (ReportUri != null)
                 {

--- a/src/Joonasw.AspNetCore.SecurityHeaders/ExpectCT/ExpectCTOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/ExpectCT/ExpectCTOptions.cs
@@ -7,6 +7,10 @@ namespace Joonasw.AspNetCore.SecurityHeaders.ExpectCT
     /// </summary>
     public class ExpectCTOptions
     {
+        /// <summary>
+        /// Defines the parameters for the Expect-CT header with only the max-age set to 30 days.
+        /// Please see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT for support and more info
+        /// </summary>
         public ExpectCTOptions()
         {
             
@@ -14,16 +18,15 @@ namespace Joonasw.AspNetCore.SecurityHeaders.ExpectCT
 
         /// <summary>
         /// Defines the parameters for the Expect-CT header sent to clients.
-        /// NOT CURRENTLY SUPPORTED
+        /// Please see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT for support and more info
         /// </summary>
         /// <param name="maxAge">The required max-age directive specifies the number of seconds that
         /// the browser should cache and apply the received policy for, whether enforced or report-only.</param>
         /// <param name="reportUri">the report-uri directive specifies where the browser should send reports
         /// if it does not receive valid CT information. This is specified as an absolute URI.</param>
         /// <param name="enforce">The optional enforce directive controls whether the browser should
-        /// enforce the policy or treat it as report-only mode. The directive has no value so you simply
-        /// include it or not depending on whether or not you want the browser to enforce the policy
-        /// or just report on it.</param>
+        /// enforce the policy. Omitting this will treat it as report-only mode. The directive has no value so you simply
+        /// include it or not depending on whether or not you want the browser to enforce the policy.</param>
         public ExpectCTOptions(TimeSpan maxAge, string reportUri, bool enforce = false)
         {
             MaxAge = maxAge;
@@ -32,26 +35,26 @@ namespace Joonasw.AspNetCore.SecurityHeaders.ExpectCT
         }
 
         /// <summary>
-        /// Gets the maxAge browsers should remember that
-        /// this domain should only be accessed over HTTPS.
+        /// Specifies the TimeSpan from seconds after reception of the Expect-CT header field
+        /// during which the user agent should regard the host from whom the message was
+        /// received as a known Expect-CT host.
         /// </summary>
         public TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(30);
 
         /// <summary>
-        /// Gets the maxAge browsers should remember
-        /// this domain should only be accessed over HTTPS,
-        /// in seconds.
+        /// Specifies the number of seconds after reception of the Expect-CT header field
+        /// during which the user agent should regard the host from whom the message was
+        /// received as a known Expect-CT host.
         /// </summary>
         public int DurationSeconds => (int)MaxAge.TotalSeconds;
 
         /// <summary>
-        /// Gets if this rule should apply to the current host.
+        /// If true, browsers will enforce the Certificate Transparency policy and refuse future connections that violate the policy.
         /// </summary>
         public bool Enforce { get; set; }
 
         /// <summary>
-        /// Gets if this domain should be allowed to be
-        /// added to preload lists in browsers.
+        /// The URL where violation reports should be sent.
         /// </summary>
         public string ReportUri { get; set; }
 
@@ -66,11 +69,11 @@ namespace Joonasw.AspNetCore.SecurityHeaders.ExpectCT
                     value += "enforce";
                 }
 
-                value += "; " + "max-age=" + DurationSeconds;
+                value += ", " + "max-age=" + DurationSeconds;
 
                 if (ReportUri != null)
                 {
-                    value += "; report-uri=\"" + ReportUri + "\"";
+                    value += ", report-uri=\"" + ReportUri + "\"";
                 }
 
                 return value;

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyAccelerometerBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyAccelerometerBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyAccelerometerBuilder : IFeaturePolicyBuilder<FeaturePolicyAccelerometerBuilder>
+    {
+        private readonly FeaturePolicyAccelerometerOptions _options = new FeaturePolicyAccelerometerOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyAccelerometerBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyAccelerometerBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyAccelerometerBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyAccelerometerOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyAmbientLightSensorBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyAmbientLightSensorBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyAmbientLightSensorBuilder : IFeaturePolicyBuilder<FeaturePolicyAmbientLightSensorBuilder>
+    {
+        private readonly FeaturePolicyAmbientLightSensorOptions _options = new FeaturePolicyAmbientLightSensorOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyAmbientLightSensorBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyAmbientLightSensorBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyAmbientLightSensorBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyAmbientLightSensorOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyAutoplayBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyAutoplayBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyAutoplayBuilder : IFeaturePolicyBuilder<FeaturePolicyAutoplayBuilder>
+    {
+        private readonly FeaturePolicyAutoplayOptions _options = new FeaturePolicyAutoplayOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyAutoplayBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyAutoplayBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyAutoplayBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyAutoplayOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyBuilder.cs
@@ -59,6 +59,34 @@
         /// Set up rules for Payment use
         /// </summary>
         public FeaturePolicyPaymentBuilder AllowPayment { get; } = new FeaturePolicyPaymentBuilder();
+        /// <summary>
+        /// Set up rules for Accelerometer use
+        /// </summary>
+        public FeaturePolicyAccelerometerBuilder AllowAccelerometer { get; } = new FeaturePolicyAccelerometerBuilder();
+        /// <summary>
+        /// Set up rules for Ambient Light Sensor use
+        /// </summary>
+        public FeaturePolicyAmbientLightSensorBuilder AllowAmbientLightSensor { get; } = new FeaturePolicyAmbientLightSensorBuilder();
+        /// <summary>
+        /// Set up rules for Autoplay use
+        /// </summary>
+        public FeaturePolicyAutoplayBuilder AllowAutoplay { get; } = new FeaturePolicyAutoplayBuilder();
+        /// <summary>
+        /// Set up rules for Encrypted Media use
+        /// </summary>
+        public FeaturePolicyEncryptedMediaBuilder AllowEncryptedMedia { get; } = new FeaturePolicyEncryptedMediaBuilder();
+        /// <summary>
+        /// Set up rules for Picture in Picture use
+        /// </summary>
+        public FeaturePolicyPictureInPictureBuilder AllowPictureInPicture { get; } = new FeaturePolicyPictureInPictureBuilder();
+        /// <summary>
+        /// Set up rules for USB use
+        /// </summary>
+        public FeaturePolicyUsbBuilder AllowUsb { get; } = new FeaturePolicyUsbBuilder();
+        /// <summary>
+        /// Set up rules for VR use
+        /// </summary>
+        public FeaturePolicyVrBuilder AllowVr { get; } = new FeaturePolicyVrBuilder();
 
         internal FeaturePolicyOptions BuildFeaturePolicyOptions()
         {
@@ -75,6 +103,13 @@
             _options.VibrateOptions = AllowVibrate.BuildOptions();
             _options.FullscreenOptions = AllowFullscreen.BuildOptions();
             _options.PaymentOptions = AllowPayment.BuildOptions();
+            _options.AccelerometerOptions = AllowAccelerometer.BuildOptions();
+            _options.AmbientLightSensorOptions = AllowAmbientLightSensor.BuildOptions();
+            _options.AutoplayOptions = AllowAutoplay.BuildOptions();
+            _options.EncryptedMediaOptions = AllowEncryptedMedia.BuildOptions();
+            _options.PictureInPictureOptions = AllowPictureInPicture.BuildOptions();
+            _options.UsbOptions = AllowUsb.BuildOptions();
+            _options.VrOptions = AllowVr.BuildOptions();
 
             return _options;
         }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyBuilder.cs
@@ -1,0 +1,82 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyBuilder
+    {
+        private readonly  FeaturePolicyOptions _options = new FeaturePolicyOptions();
+
+        /// <summary>
+        /// Set up rules for Geolocation.
+        /// </summary>
+        public FeaturePolicyGeolocationBuilder AllowGeolocation { get; } = new FeaturePolicyGeolocationBuilder();
+        /// <summary>
+        /// Set up rules for Midi
+        /// </summary>
+        public FeaturePolicyMidiBuilder AllowMidi { get; } = new FeaturePolicyMidiBuilder();
+        /// <summary>
+        /// Set up rules for Notifications
+        /// No Chrome support as of 2017-07-30
+        /// </summary>
+        public FeaturePolicyNotificationsBuilder AllowNotifications { get; } = new FeaturePolicyNotificationsBuilder();
+        /// <summary>
+        /// Set up rules for Push
+        /// No Chrome support as of 2017-07-30
+        /// </summary>
+        public FeaturePolicyPushBuilder AllowPush { get; } = new FeaturePolicyPushBuilder();
+        /// <summary>
+        /// Set up rules for Sync Xhr
+        /// </summary>
+        public FeaturePolicySyncXhrBuilder AllowSyncXhr { get; } = new FeaturePolicySyncXhrBuilder();
+        /// <summary>
+        /// Set up rules for Microphone use
+        /// </summary>
+        public FeaturePolicyMicrophoneBuilder AllowMicrophone { get; } = new FeaturePolicyMicrophoneBuilder();
+        /// <summary>
+        /// Set up rules for Camera use
+        /// </summary>
+        public FeaturePolicyCameraBuilder AllowCamera { get; } = new FeaturePolicyCameraBuilder();
+        /// <summary>
+        /// Set up rules for Magnetometer
+        /// </summary>
+        public FeaturePolicyMagnetometerBuilder AllowMagnetometer { get; } = new FeaturePolicyMagnetometerBuilder();
+        /// <summary>
+        /// Set up rules for Gyroscope
+        /// </summary>
+        public FeaturePolicyGyroscopeBuilder AllowGyroscope { get; } = new FeaturePolicyGyroscopeBuilder();
+        /// <summary>
+        /// Set up rules for Speaker use
+        /// </summary>
+        public FeaturePolicySpeakerBuilder AllowSpeaker { get; } = new FeaturePolicySpeakerBuilder();
+        /// <summary>
+        /// Set up rules for Vibrate
+        /// No Chrome support as of 2017-07-30
+        /// </summary>
+        public FeaturePolicyVibrateBuilder AllowVibrate { get; } = new FeaturePolicyVibrateBuilder();
+        /// <summary>
+        /// Set up rules for Fullscreen use
+        /// </summary>
+        public FeaturePolicyFullscreenBuilder AllowFullscreen { get; } = new FeaturePolicyFullscreenBuilder();
+        /// <summary>
+        /// Set up rules for Payment use
+        /// </summary>
+        public FeaturePolicyPaymentBuilder AllowPayment { get; } = new FeaturePolicyPaymentBuilder();
+
+        internal FeaturePolicyOptions BuildFeaturePolicyOptions()
+        {
+            _options.GeolocationOptions = AllowGeolocation.BuildOptions();
+            _options.MidiOptions = AllowMidi.BuildOptions();
+            _options.NotificationsOptions = AllowNotifications.BuildOptions();
+            _options.PushOptions = AllowPush.BuildOptions();
+            _options.SyncXhrOptions = AllowSyncXhr.BuildOptions();
+            _options.MicrophoneOptions = AllowMicrophone.BuildOptions();
+            _options.CameraOptions = AllowCamera.BuildOptions();
+            _options.MagnetometerOptions = AllowMagnetometer.BuildOptions();
+            _options.GyroscopeOptions = AllowGyroscope.BuildOptions();
+            _options.SpeakerOptions = AllowSpeaker.BuildOptions();
+            _options.VibrateOptions = AllowVibrate.BuildOptions();
+            _options.FullscreenOptions = AllowFullscreen.BuildOptions();
+            _options.PaymentOptions = AllowPayment.BuildOptions();
+
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyCameraBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyCameraBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyCameraBuilder : IFeaturePolicyBuilder<FeaturePolicyCameraBuilder>
+    {
+        private readonly FeaturePolicyCameraOptions _options = new FeaturePolicyCameraOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyCameraBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyCameraBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyCameraBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyCameraOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyEncryptedMediaBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyEncryptedMediaBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyEncryptedMediaBuilder : IFeaturePolicyBuilder<FeaturePolicyEncryptedMediaBuilder>
+    {
+        private readonly FeaturePolicyEncryptedMediaOptions _options = new FeaturePolicyEncryptedMediaOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyEncryptedMediaBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyEncryptedMediaBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyEncryptedMediaBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyEncryptedMediaOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyFullscreenBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyFullscreenBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyFullscreenBuilder : IFeaturePolicyBuilder<FeaturePolicyFullscreenBuilder>
+    {
+        private readonly FeaturePolicyFullscreenOptions _options = new FeaturePolicyFullscreenOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyFullscreenBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyFullscreenBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyFullscreenBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyFullscreenOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyGeolocationBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyGeolocationBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyGeolocationBuilder : IFeaturePolicyBuilder<FeaturePolicyGeolocationBuilder>
+    {
+        private readonly FeaturePolicyGeolocationOptions _options = new FeaturePolicyGeolocationOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyGeolocationBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyGeolocationBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyGeolocationBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyGeolocationOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyGyroscopeBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyGyroscopeBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyGyroscopeBuilder : IFeaturePolicyBuilder<FeaturePolicyGyroscopeBuilder>
+    {
+        private readonly FeaturePolicyGyroscopeOptions _options = new FeaturePolicyGyroscopeOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyGyroscopeBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyGyroscopeBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyGyroscopeBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyGyroscopeOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyMagnetometerBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyMagnetometerBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyMagnetometerBuilder : IFeaturePolicyBuilder<FeaturePolicyMagnetometerBuilder>
+    {
+        private readonly FeaturePolicyMagnetometerOptions _options = new FeaturePolicyMagnetometerOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyMagnetometerBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyMagnetometerBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyMagnetometerBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyMagnetometerOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyMicrophoneBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyMicrophoneBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyMicrophoneBuilder : IFeaturePolicyBuilder<FeaturePolicyMicrophoneBuilder>
+    {
+        private readonly FeaturePolicyMicrophoneOptions _options = new FeaturePolicyMicrophoneOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyMicrophoneBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyMicrophoneBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyMicrophoneBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyMicrophoneOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyMidiBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyMidiBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyMidiBuilder : IFeaturePolicyBuilder<FeaturePolicyMidiBuilder>
+    {
+        private readonly FeaturePolicyMidiOptions _options = new FeaturePolicyMidiOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyMidiBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyMidiBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyMidiBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyMidiOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyNotificationsBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyNotificationsBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyNotificationsBuilder : IFeaturePolicyBuilder<FeaturePolicyNotificationsBuilder>
+    {
+        private readonly FeaturePolicyNotificationsOptions _options = new FeaturePolicyNotificationsOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyNotificationsBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyNotificationsBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyNotificationsBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyNotificationsOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyPaymentBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyPaymentBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyPaymentBuilder : IFeaturePolicyBuilder<FeaturePolicyPaymentBuilder>
+    {
+        private readonly FeaturePolicyPaymentOptions _options = new FeaturePolicyPaymentOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyPaymentBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyPaymentBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyPaymentBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyPaymentOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyPictureInPictureBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyPictureInPictureBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyPictureInPictureBuilder : IFeaturePolicyBuilder<FeaturePolicyPictureInPictureBuilder>
+    {
+        private readonly FeaturePolicyPictureInPictureOptions _options = new FeaturePolicyPictureInPictureOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyPictureInPictureBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyPictureInPictureBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyPictureInPictureBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyPictureInPictureOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyPushBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyPushBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyPushBuilder : IFeaturePolicyBuilder<FeaturePolicyPushBuilder>
+    {
+        private readonly FeaturePolicyPushOptions _options = new FeaturePolicyPushOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyPushBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyPushBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyPushBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyPushOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicySpeakerBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicySpeakerBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicySpeakerBuilder : IFeaturePolicyBuilder<FeaturePolicySpeakerBuilder>
+    {
+        private readonly FeaturePolicySpeakerOptions _options = new FeaturePolicySpeakerOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicySpeakerBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicySpeakerBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicySpeakerBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicySpeakerOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicySyncXhrBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicySyncXhrBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicySyncXhrBuilder : IFeaturePolicyBuilder<FeaturePolicySyncXhrBuilder>
+    {
+        private readonly FeaturePolicySyncXhrOptions _options = new FeaturePolicySyncXhrOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicySyncXhrBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicySyncXhrBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicySyncXhrBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicySyncXhrOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyUsbBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyUsbBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyUsbBuilder : IFeaturePolicyBuilder<FeaturePolicyUsbBuilder>
+    {
+        private readonly FeaturePolicyUsbOptions _options = new FeaturePolicyUsbOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyUsbBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyUsbBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyUsbBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyUsbOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyVibrateBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyVibrateBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyVibrateBuilder : IFeaturePolicyBuilder<FeaturePolicyVibrateBuilder>
+    {
+        private readonly FeaturePolicyVibrateOptions _options = new FeaturePolicyVibrateOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyVibrateBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyVibrateBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyVibrateBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyVibrateOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyVrBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/FeaturePolicyVrBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    public class FeaturePolicyVrBuilder : IFeaturePolicyBuilder<FeaturePolicyVrBuilder>
+    {
+        private readonly FeaturePolicyVrOptions _options = new FeaturePolicyVrOptions();
+
+        /// <inheritdoc />
+        public void FromNowhere()
+        {
+            _options.AllowNone = true;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyVrBuilder FromSelf()
+        {
+            _options.AllowSelf = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyVrBuilder FromAnywhere()
+        {
+            _options.AllowAny = true;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public FeaturePolicyVrBuilder From(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (uri.Length == 0) throw new ArgumentException("Uri can't be empty", nameof(uri));
+
+            _options.AllowedOrigins.Add(uri);
+            return this;
+        }
+
+        internal FeaturePolicyVrOptions BuildOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/IFeaturePolicyBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/IFeaturePolicyBuilder.cs
@@ -3,7 +3,7 @@
     internal interface IFeaturePolicyBuilder<out T>
     {
         /// <summary>
-        /// Block all
+        /// Block access to feature from all domains.
         /// </summary>
         void FromNowhere();
         /// <summary>
@@ -12,8 +12,7 @@
         /// <returns></returns>
         T FromSelf();
         /// <summary>
-        /// Allowed from anywhere, except
-        /// data:, blob:, and filesystem: schemes.
+        /// Allowed from any domain.
         /// </summary>
         /// <returns></returns>
         T FromAnywhere();

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/IFeaturePolicyBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Builder/IFeaturePolicyBuilder.cs
@@ -1,0 +1,28 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Builder
+{
+    internal interface IFeaturePolicyBuilder<out T>
+    {
+        /// <summary>
+        /// Block all
+        /// </summary>
+        void FromNowhere();
+        /// <summary>
+        /// Allowed from current domain.
+        /// </summary>
+        /// <returns></returns>
+        T FromSelf();
+        /// <summary>
+        /// Allowed from anywhere, except
+        /// data:, blob:, and filesystem: schemes.
+        /// </summary>
+        /// <returns></returns>
+        T FromAnywhere();
+        /// <summary>
+        /// Allowed from the given
+        /// <paramref name="uri"/>.
+        /// </summary>
+        /// <param name="uri">The URI to allow.</param>
+        /// <returns>The builder for call chaining</returns>
+        T From(string uri);
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/FeaturePolicyMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/FeaturePolicyMiddleware.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy
+{
+    public class FeaturePolicyMiddleware
+    {
+        private const string HeaderName = "Feature-Policy";
+        private readonly RequestDelegate _next;
+        private readonly string _headerValue;
+
+        public FeaturePolicyMiddleware(RequestDelegate next, IOptions<FeaturePolicyOptions> options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _next = next;
+            _headerValue = options.Value.ToString();
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            // Check if a Feature Policy header has already been added to the response
+            // This can happen for example if a middleware re-executes the pipeline
+            if (!ContainsFeaturePolicyHeader(context.Response))
+            {
+                context.Response.Headers.Add(HeaderName, _headerValue);
+            }
+
+            await _next.Invoke(context);
+        }
+
+        private static bool ContainsFeaturePolicyHeader(HttpResponse response)
+        {
+            return response.Headers.Any(h => h.Key.Equals(HeaderName, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/FeaturePolicyOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/FeaturePolicyOptions.cs
@@ -22,6 +22,13 @@ namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy
             VibrateOptions = new FeaturePolicyVibrateOptions();
             FullscreenOptions = new FeaturePolicyFullscreenOptions();
             PaymentOptions = new FeaturePolicyPaymentOptions();
+            AccelerometerOptions = new FeaturePolicyAccelerometerOptions();
+            AmbientLightSensorOptions = new FeaturePolicyAmbientLightSensorOptions();
+            AutoplayOptions = new FeaturePolicyAutoplayOptions();
+            EncryptedMediaOptions = new FeaturePolicyEncryptedMediaOptions();
+            PictureInPictureOptions = new FeaturePolicyPictureInPictureOptions();
+            UsbOptions = new FeaturePolicyUsbOptions();
+            VrOptions = new FeaturePolicyVrOptions();
         }
 
         public FeaturePolicyGeolocationOptions GeolocationOptions { get; set; }
@@ -37,8 +44,15 @@ namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy
         public FeaturePolicyVibrateOptions VibrateOptions { get; set; }
         public FeaturePolicyFullscreenOptions FullscreenOptions { get; set; }
         public FeaturePolicyPaymentOptions PaymentOptions { get; set; }
+        public FeaturePolicyAccelerometerOptions AccelerometerOptions { get; set; }
+        public FeaturePolicyAmbientLightSensorOptions AmbientLightSensorOptions { get; set; }
+        public FeaturePolicyAutoplayOptions AutoplayOptions { get; set; }
+        public FeaturePolicyEncryptedMediaOptions EncryptedMediaOptions { get; set; }
+        public FeaturePolicyPictureInPictureOptions PictureInPictureOptions { get; set; }
+        public FeaturePolicyUsbOptions UsbOptions { get; set; }
+        public FeaturePolicyVrOptions VrOptions { get; set; }
 
-        internal enum FeaturePolicyValues
+        internal enum FeaturePolicyValue
         {
             [DefaultValue("geolocation")]
             Geolocation = 0,
@@ -66,6 +80,20 @@ namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy
             Fullscreen = 11,
             [DefaultValue("payment")]
             Payment = 12,
+            [DefaultValue("accelerometer")]
+            Accelerometer = 13,
+            [DefaultValue("ambient-light-sensor")]
+            AmbientLightSensor = 14,
+            [DefaultValue("autoplay")]
+            Autoplay = 15,
+            [DefaultValue("encrypted-media")]
+            EncryptedMedia = 16,
+            [DefaultValue("picture-in-picture")]
+            PictureInPicture = 17,
+            [DefaultValue("usb")]
+            Usb = 18,
+            [DefaultValue("vr")]
+            Vr = 19
         }
 
         /// <summary>
@@ -88,7 +116,14 @@ namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy
                 SpeakerOptions.ToString(),
                 VibrateOptions.ToString(),
                 FullscreenOptions.ToString(),
-                PaymentOptions.ToString()
+                PaymentOptions.ToString(),
+                AccelerometerOptions.ToString(),
+                AmbientLightSensorOptions.ToString(),
+                AutoplayOptions.ToString(),
+                EncryptedMediaOptions.ToString(),
+                PictureInPictureOptions.ToString(),
+                UsbOptions.ToString(),
+                VrOptions.ToString()
             };
             return string.Join("; ", optionValues.Where(s => s.Length > 0));
         }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/FeaturePolicyOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/FeaturePolicyOptions.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy
+{
+    public class FeaturePolicyOptions
+    {
+        public FeaturePolicyOptions()
+        {
+            GeolocationOptions = new FeaturePolicyGeolocationOptions();
+            MidiOptions = new FeaturePolicyMidiOptions();
+            NotificationsOptions = new FeaturePolicyNotificationsOptions();
+            PushOptions = new FeaturePolicyPushOptions();
+            SyncXhrOptions = new FeaturePolicySyncXhrOptions();
+            MicrophoneOptions = new FeaturePolicyMicrophoneOptions();
+            CameraOptions = new FeaturePolicyCameraOptions();
+            MagnetometerOptions = new FeaturePolicyMagnetometerOptions();
+            GyroscopeOptions = new FeaturePolicyGyroscopeOptions();
+            SpeakerOptions = new FeaturePolicySpeakerOptions();
+            VibrateOptions = new FeaturePolicyVibrateOptions();
+            FullscreenOptions = new FeaturePolicyFullscreenOptions();
+            PaymentOptions = new FeaturePolicyPaymentOptions();
+        }
+
+        public FeaturePolicyGeolocationOptions GeolocationOptions { get; set; }
+        public FeaturePolicyMidiOptions MidiOptions { get; set; }
+        public FeaturePolicyNotificationsOptions NotificationsOptions { get; set; }
+        public FeaturePolicyPushOptions PushOptions { get; set; }
+        public FeaturePolicySyncXhrOptions SyncXhrOptions { get; set; }
+        public FeaturePolicyMicrophoneOptions MicrophoneOptions { get; set; }
+        public FeaturePolicyCameraOptions CameraOptions { get; set; }
+        public FeaturePolicyMagnetometerOptions MagnetometerOptions { get; set; }
+        public FeaturePolicyGyroscopeOptions GyroscopeOptions { get; set; }
+        public FeaturePolicySpeakerOptions SpeakerOptions { get; set; }
+        public FeaturePolicyVibrateOptions VibrateOptions { get; set; }
+        public FeaturePolicyFullscreenOptions FullscreenOptions { get; set; }
+        public FeaturePolicyPaymentOptions PaymentOptions { get; set; }
+
+        internal enum FeaturePolicyValues
+        {
+            [DefaultValue("geolocation")]
+            Geolocation = 0,
+            [DefaultValue("midi")]
+            Midi = 1,
+            [DefaultValue("notifications")]
+            Notifications = 2,
+            [DefaultValue("push")]
+            Push = 3,
+            [DefaultValue("sync-xhr")]
+            SyncXhr = 4,
+            [DefaultValue("microphone")]
+            Microphone = 5,
+            [DefaultValue("camera")]
+            Camera = 6,
+            [DefaultValue("magnetometer")]
+            Magnetometer = 7,
+            [DefaultValue("gyroscope")]
+            Gyroscope = 8,
+            [DefaultValue("speaker")]
+            Speaker = 9,
+            [DefaultValue("vibrate")]
+            Vibrate = 10,
+            [DefaultValue("fullscreen")]
+            Fullscreen = 11,
+            [DefaultValue("payment")]
+            Payment = 12,
+        }
+
+        /// <summary>
+        /// Override to add all values from all options
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var optionValues = new List<string>
+            {
+                GeolocationOptions.ToString(),
+                MidiOptions.ToString(),
+                NotificationsOptions.ToString(),
+                PushOptions.ToString(),
+                SyncXhrOptions.ToString(),
+                MicrophoneOptions.ToString(),
+                CameraOptions.ToString(),
+                MagnetometerOptions.ToString(),
+                GyroscopeOptions.ToString(),
+                SpeakerOptions.ToString(),
+                VibrateOptions.ToString(),
+                FullscreenOptions.ToString(),
+                PaymentOptions.ToString()
+            };
+            return string.Join("; ", optionValues.Where(s => s.Length > 0));
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyAccelerometerOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyAccelerometerOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyAccelerometerOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyAccelerometerOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Accelerometer.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyAmbientLightSensorOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyAmbientLightSensorOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyAmbientLightSensorOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyAmbientLightSensorOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValue.AmbientLightSensor.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyAutoplayOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyAutoplayOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyAutoplayOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyAutoplayOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Autoplay.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyCameraOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyCameraOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyCameraOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyCameraOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Camera.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyCameraOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyCameraOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyCameraOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyCameraOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Camera.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Camera.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyEncryptedMediaOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyEncryptedMediaOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyEncryptedMediaOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyEncryptedMediaOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValue.EncryptedMedia.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyFullscreenOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyFullscreenOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyFullscreenOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyFullscreenOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Fullscreen.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Fullscreen.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyFullscreenOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyFullscreenOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyFullscreenOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyFullscreenOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Fullscreen.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyGeolocationOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyGeolocationOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyGeolocationOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyGeolocationOptions() 
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Geolocation.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyGeolocationOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyGeolocationOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyGeolocationOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyGeolocationOptions() 
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Geolocation.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Geolocation.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyGyroscopeOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyGyroscopeOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyGyroscopeOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyGyroscopeOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Gyroscope.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyGyroscopeOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyGyroscopeOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyGyroscopeOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyGyroscopeOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Gyroscope.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Gyroscope.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMagnetometerOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMagnetometerOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyMagnetometerOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyMagnetometerOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Magnetometer.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMagnetometerOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMagnetometerOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyMagnetometerOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyMagnetometerOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Magnetometer.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Magnetometer.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMicrophoneOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMicrophoneOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyMicrophoneOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyMicrophoneOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Microphone.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMicrophoneOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMicrophoneOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyMicrophoneOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyMicrophoneOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Microphone.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Microphone.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMidiOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMidiOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyMidiOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyMidiOptions() 
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Midi.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMidiOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyMidiOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyMidiOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyMidiOptions() 
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Midi.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Midi.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyNotificationsOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyNotificationsOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyNotificationsOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyNotificationsOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Notifications.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Notifications.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyNotificationsOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyNotificationsOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyNotificationsOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyNotificationsOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Notifications.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyOriginsBase.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyOriginsBase.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public abstract class FeaturePolicyOptionsBase
+    {
+        private readonly string _directiveName;
+        /// <summary>
+        /// Collection of origins from where these resources can be loaded.
+        /// </summary>
+        public ICollection<string> AllowedOrigins { get; set; }
+        /// <summary>
+        /// Allow loading these resources from the same domain as the app.
+        /// </summary>
+        public bool AllowSelf { get; set; }
+        /// <summary>
+        /// Block loading of these resources.
+        /// </summary>
+        public bool AllowNone { get; set; }
+        /// <summary>
+        /// Allows any source except data:, blob:, and filesystem: schemes.
+        /// </summary>
+        public bool AllowAny { get; set; }
+
+        protected FeaturePolicyOptionsBase(string directiveName)
+        {
+            _directiveName = directiveName;
+            AllowedOrigins = new List<string>();   
+        }
+
+        protected virtual ICollection<string> GetParts()
+        {
+            ICollection<string> parts = new List<string>();
+
+            if (AllowNone)
+            {
+                parts.Add("'none'");
+            }
+            else
+            {
+                if (AllowAny)
+                {
+                    parts.Add("*");
+                }
+                if (AllowSelf)
+                {
+                    parts.Add("'self'");
+                }
+                if (AllowedOrigins.Count > 0)
+                {
+                    parts.Add(string.Join(" ", AllowedOrigins));
+                }
+            }
+            return parts;
+        }
+
+        public override string ToString()
+        {
+            var parts = GetParts();
+
+            if (parts.Count == 0)
+            {
+                return string.Empty;
+            }
+            return $"{_directiveName} {string.Join(" ", parts)}";
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyOriginsBase.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyOriginsBase.cs
@@ -58,11 +58,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
         {
             var parts = GetParts();
 
-            if (parts.Count == 0)
-            {
-                return string.Empty;
-            }
-            return $"{_directiveName} {string.Join(" ", parts)}";
+            return parts.Count == 0 ? string.Empty : $"{_directiveName} {string.Join(" ", parts)}";
         }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyPaymentOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyPaymentOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyPaymentOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyPaymentOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Payment.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Payment.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyPaymentOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyPaymentOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyPaymentOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyPaymentOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Payment.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyPictureInPictureOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyPictureInPictureOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyPictureInPictureOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyPictureInPictureOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValue.PictureInPicture.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyPushOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyPushOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyPushOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyPushOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Push.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Push.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyPushOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyPushOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyPushOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyPushOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Push.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicySpeakerOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicySpeakerOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicySpeakerOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicySpeakerOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Speaker.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Speaker.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicySpeakerOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicySpeakerOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicySpeakerOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicySpeakerOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Speaker.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicySyncXhrOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicySyncXhrOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicySyncXhrOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicySyncXhrOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.SyncXhr.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.SyncXhr.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicySyncXhrOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicySyncXhrOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicySyncXhrOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicySyncXhrOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.SyncXhr.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyUsbOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyUsbOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyUsbOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyUsbOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Usb.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyVibrateOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyVibrateOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyVibrateOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyVibrateOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValues.Vibrate.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyVibrateOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyVibrateOptions.cs
@@ -3,6 +3,6 @@
     public class FeaturePolicyVibrateOptions : FeaturePolicyOptionsBase
     {
         public FeaturePolicyVibrateOptions()
-            : base(FeaturePolicyOptions.FeaturePolicyValues.Vibrate.DefaultValue()) { }
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Vibrate.DefaultValue()) { }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyVrOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/FeaturePolicy/Options/FeaturePolicyVrOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.FeaturePolicy.Options
+{
+    public class FeaturePolicyVrOptions : FeaturePolicyOptionsBase
+    {
+        public FeaturePolicyVrOptions()
+            : base(FeaturePolicyOptions.FeaturePolicyValue.Vr.DefaultValue()) { }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Hpkp/HpkpOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Hpkp/HpkpOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Joonasw.AspNetCore.SecurityHeaders
+namespace Joonasw.AspNetCore.SecurityHeaders.Hpkp
 {
     public class HpkpOptions
     {

--- a/src/Joonasw.AspNetCore.SecurityHeaders/HpkpOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/HpkpOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Joonasw.AspNetCore.SecurityHeaders.Hpkp
+namespace Joonasw.AspNetCore.SecurityHeaders
 {
     public class HpkpOptions
     {

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Hsts/HstsOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Hsts/HstsOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Joonasw.AspNetCore.SecurityHeaders
+namespace Joonasw.AspNetCore.SecurityHeaders.Hsts
 {
     /// <summary>
     /// Options for the HTTP Strict Transport Security header.

--- a/src/Joonasw.AspNetCore.SecurityHeaders/HstsOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/HstsOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Joonasw.AspNetCore.SecurityHeaders.Hsts
+namespace Joonasw.AspNetCore.SecurityHeaders
 {
     /// <summary>
     /// Options for the HTTP Strict Transport Security header.

--- a/src/Joonasw.AspNetCore.SecurityHeaders/ReferrerPolicy/ReferrerPolicyMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/ReferrerPolicy/ReferrerPolicyMiddleware.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.ReferrerPolicy
+{
+    public class ReferrerPolicyMiddleware
+    {
+        private const string HeaderName = "Referrer-Policy";
+        private readonly RequestDelegate _next;
+        private readonly string _headerValue;
+
+        public ReferrerPolicyMiddleware(RequestDelegate next, IOptions<ReferrerPolicyOptions> options)
+        {
+            _next = next;
+            _headerValue = options.Value.ReferrerPolicyValue.DefaultValue();
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            context.Response.Headers.Add(HeaderName, _headerValue);
+            await _next(context);
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/ReferrerPolicy/ReferrerPolicyMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/ReferrerPolicy/ReferrerPolicyMiddleware.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -13,13 +15,21 @@ namespace Joonasw.AspNetCore.SecurityHeaders.ReferrerPolicy
         public ReferrerPolicyMiddleware(RequestDelegate next, IOptions<ReferrerPolicyOptions> options)
         {
             _next = next;
-            _headerValue = options.Value.ReferrerPolicyValue.DefaultValue();
+            _headerValue = options.Value.HeaderValue.DefaultValue();
         }
 
         public async Task Invoke(HttpContext context)
         {
-            context.Response.Headers.Add(HeaderName, _headerValue);
+            if (!ContainsReferrerPolicyHeader(context.Response))
+            {
+                context.Response.Headers.Add(HeaderName, _headerValue);
+            }
             await _next(context);
+        }
+
+        private static bool ContainsReferrerPolicyHeader(HttpResponse response)
+        {
+            return response.Headers.Any(h => h.Key.Equals(HeaderName, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/ReferrerPolicy/ReferrerPolicyOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/ReferrerPolicy/ReferrerPolicyOptions.cs
@@ -4,27 +4,30 @@ namespace Joonasw.AspNetCore.SecurityHeaders.ReferrerPolicy
 {
     public class ReferrerPolicyOptions
     {
+        /// <summary>
+        /// Defines the parameters for the Referrer Policy header with the 'no-referrer' option set
+        /// </summary>
         public ReferrerPolicyOptions()
         {
             
         }
 
         /// <summary>
-        /// Defined the parameters for the Referrer Policy header sent in the response to the client
+        /// Defines the parameters for the Referrer Policy header sent in the response to the client
         /// </summary>
         /// <param name="value">The value to be applied to the Referrer Policy header</param>
-        public ReferrerPolicyOptions(ReferrerPolicyValues value)
+        public ReferrerPolicyOptions(ReferrerPolicyValue value)
         {
-            ReferrerPolicyValue = value;
+            HeaderValue = value;
         }
 
         /// <summary>
         /// Gets the referrer policy value to be applied to the ReferrerPolicy header
         /// no-referrer is set by default
         /// </summary>
-        public ReferrerPolicyValues ReferrerPolicyValue { get; set; } = ReferrerPolicyValues.NoReferrer;
+        public ReferrerPolicyValue HeaderValue { get; set; } = ReferrerPolicyValue.NoReferrer;
 
-        public enum ReferrerPolicyValues
+        public enum ReferrerPolicyValue
         {
             [DefaultValue("")]
             None = 0,

--- a/src/Joonasw.AspNetCore.SecurityHeaders/ReferrerPolicy/ReferrerPolicyOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/ReferrerPolicy/ReferrerPolicyOptions.cs
@@ -1,0 +1,49 @@
+﻿using System.ComponentModel;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.ReferrerPolicy
+{
+    public class ReferrerPolicyOptions
+    {
+        public ReferrerPolicyOptions()
+        {
+            
+        }
+
+        /// <summary>
+        /// Defined the parameters for the Referrer Policy header sent in the response to the client
+        /// </summary>
+        /// <param name="value">The value to be applied to the Referrer Policy header</param>
+        public ReferrerPolicyOptions(ReferrerPolicyValues value)
+        {
+            ReferrerPolicyValue = value;
+        }
+
+        /// <summary>
+        /// Gets the referrer policy value to be applied to the ReferrerPolicy header
+        /// no-referrer is set by default
+        /// </summary>
+        public ReferrerPolicyValues ReferrerPolicyValue { get; set; } = ReferrerPolicyValues.NoReferrer;
+
+        public enum ReferrerPolicyValues
+        {
+            [DefaultValue("")]
+            None = 0,
+            [DefaultValue("no-referrer")]
+            NoReferrer = 1,
+            [DefaultValue("no-referrer-when-downgrade")]
+            NoReferrerWhenDowngrade = 2,
+            [DefaultValue("same-origin")]
+            SameOrigin = 3,
+            [DefaultValue("origin")]
+            Origin = 4,
+            [DefaultValue("strict-origin")]
+            StrictOrigin = 5,
+            [DefaultValue("origin-when-cross-origin")]
+            OriginWhenCrossOrigin = 6,
+            [DefaultValue("strict-origin-when-cross-origin")]
+            StrictOriginWhenCrossOrigin = 7,
+            [DefaultValue("unsafe-url")]
+            UnsafeUrl = 8
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/ServiceCollectionExtensions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/ServiceCollectionExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Joonasw.AspNetCore.SecurityHeaders.Csp;
+﻿using System;
+using System.ComponentModel;
+using System.Reflection;
+using Joonasw.AspNetCore.SecurityHeaders.Csp;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Joonasw.AspNetCore.SecurityHeaders
@@ -16,6 +19,23 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         public static IServiceCollection AddCsp(this IServiceCollection services, int nonceByteAmount = 32)
         {
             return services.AddScoped<ICspNonceService>(svcProvider => new CspNonceService(nonceByteAmount));
+        }
+
+        /// <summary>
+        /// Gets the string value associated with the the corresponding enum option
+        /// </summary>
+        /// <param name="enum">Any Enum where DefaultValue attribute is defined.</param>
+        /// <returns></returns>
+        internal static string DefaultValue(this Enum @enum)
+        {
+            var lFieldInfo = @enum.GetType().GetField(@enum.ToString());
+
+            var lDefaultValueAttribute =
+                (DefaultValueAttribute[])lFieldInfo.GetCustomAttributes(
+                    typeof(DefaultValueAttribute),
+                    false);
+
+            return lDefaultValueAttribute.Length > 0 ? lDefaultValueAttribute[0].Value.ToString() : @enum.ToString();
         }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XContentTypeOptions/XContentTypeOptionsMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XContentTypeOptions/XContentTypeOptionsMiddleware.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -19,9 +21,16 @@ namespace Joonasw.AspNetCore.SecurityHeaders.XContentTypeOptions
         public async Task Invoke(HttpContext context)
         {
             // Let's just not bother with adding the header if they want to allow sniffing
-            if (!string.IsNullOrWhiteSpace(_headerValue))
+            if (!string.IsNullOrWhiteSpace(_headerValue) && !ContainsXContentTypeOptionsHeader(context.Response))
+            {
                 context.Response.Headers.Add(HeaderName, _headerValue);
+            }
             await _next(context);
+        }
+
+        private static bool ContainsXContentTypeOptionsHeader(HttpResponse response)
+        {
+            return response.Headers.Any(h => h.Key.Equals(HeaderName, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XContentTypeOptions/XContentTypeOptionsMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XContentTypeOptions/XContentTypeOptionsMiddleware.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.XContentTypeOptions
+{
+    public class XContentTypeOptionsMiddleware
+    {
+        private const string HeaderName = "X-Content-Type-Options";
+        private readonly RequestDelegate _next;
+        private readonly string _headerValue;
+
+        public XContentTypeOptionsMiddleware(RequestDelegate next, IOptions<XContentTypeOptionsOptions> options)
+        {
+            _next = next;
+            _headerValue = options.Value.AllowSniffing ? string.Empty : "nosniff";
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            // Let's just not bother with adding the header if they want to allow sniffing
+            if (!string.IsNullOrWhiteSpace(_headerValue))
+                context.Response.Headers.Add(HeaderName, _headerValue);
+            await _next(context);
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XContentTypeOptions/XContentTypeOptionsOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XContentTypeOptions/XContentTypeOptionsOptions.cs
@@ -2,6 +2,9 @@
 {
     public class XContentTypeOptionsOptions
     {
+        /// <summary>
+        /// Defines the X-Content-Type-Options header with the 'nosniff' option
+        /// </summary>
         public XContentTypeOptionsOptions()
         {
             
@@ -9,7 +12,6 @@
 
         /// <summary>
         /// Defines the X-Content-Type-Options header and whether to allow sniffing
-        /// NoSniff is turned on by default
         /// </summary>
         /// <param name="allowSniffing"></param>
         public XContentTypeOptionsOptions(bool allowSniffing)

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XContentTypeOptions/XContentTypeOptionsOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XContentTypeOptions/XContentTypeOptionsOptions.cs
@@ -1,0 +1,25 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.XContentTypeOptions
+{
+    public class XContentTypeOptionsOptions
+    {
+        public XContentTypeOptionsOptions()
+        {
+            
+        }
+
+        /// <summary>
+        /// Defines the X-Content-Type-Options header and whether to allow sniffing
+        /// NoSniff is turned on by default
+        /// </summary>
+        /// <param name="allowSniffing"></param>
+        public XContentTypeOptionsOptions(bool allowSniffing)
+        {
+            AllowSniffing = allowSniffing;
+        }
+
+        /// <summary>
+        /// Gets the value to allow sniffing on your site
+        /// </summary>
+        public bool AllowSniffing { get; set; }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XFrameOptions/XFrameOptionsExtensions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XFrameOptions/XFrameOptionsExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.XFrameOptions
+{
+    internal static class XFrameOptionsExtensions
+    {
+        public static string BuildHeaderValue(this XFrameOptionsOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            var headerValue = options.HeaderValue.DefaultValue();
+            if (options.HeaderValue == XFrameOptionsOptions.XFrameOptionsValues.AllowFrom)
+            {
+                headerValue += " " + options.AllowFromUrl;
+            }
+
+            return headerValue;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XFrameOptions/XFrameOptionsMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XFrameOptions/XFrameOptionsMiddleware.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.XFrameOptions
+{
+    public class XFrameOptionsMiddleware
+    {
+        private const string HeaderName = "X-Frame-Options";
+        private readonly RequestDelegate _next;
+        private readonly string _headerValue;
+
+        public XFrameOptionsMiddleware(RequestDelegate next, IOptions<XFrameOptionsOptions> options)
+        {
+            _next = next;
+            _headerValue = options.Value.BuildHeaderValue();
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            context.Response.Headers.Add(HeaderName, _headerValue);
+            await _next(context);
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XFrameOptions/XFrameOptionsMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XFrameOptions/XFrameOptionsMiddleware.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -18,8 +20,16 @@ namespace Joonasw.AspNetCore.SecurityHeaders.XFrameOptions
 
         public async Task Invoke(HttpContext context)
         {
-            context.Response.Headers.Add(HeaderName, _headerValue);
+            if (!ContainsXFrameOptionsHeader(context.Response))
+            {
+                context.Response.Headers.Add(HeaderName, _headerValue);
+            }
             await _next(context);
+        }
+
+        private static bool ContainsXFrameOptionsHeader(HttpResponse response)
+        {
+            return response.Headers.Any(h => h.Key.Equals(HeaderName, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XFrameOptions/XFrameOptionsOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XFrameOptions/XFrameOptionsOptions.cs
@@ -5,6 +5,9 @@ namespace Joonasw.AspNetCore.SecurityHeaders.XFrameOptions
 {
     public class XFrameOptionsOptions
     {
+        /// <summary>
+        /// Defines the parameters for the X-Frame-Options header with the 'deny' option set
+        /// </summary>
         public XFrameOptionsOptions()
         {
             
@@ -23,7 +26,9 @@ namespace Joonasw.AspNetCore.SecurityHeaders.XFrameOptions
             HeaderValue = value;
 
             if (value == XFrameOptionsValues.AllowFrom && string.IsNullOrWhiteSpace(allowFromUrl))
+            {
                 throw new ArgumentException("ALLOW-FROM URL string cannot be empty when ALLOW-FROM option is selected.");
+            }
             AllowFromUrl = allowFromUrl;
         }
 

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XFrameOptions/XFrameOptionsOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XFrameOptions/XFrameOptionsOptions.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.XFrameOptions
+{
+    public class XFrameOptionsOptions
+    {
+        public XFrameOptionsOptions()
+        {
+            
+        }
+
+        /// <summary>
+        /// Defines the parameters for the X-Frame-Options header sent in response to clients
+        /// </summary>
+        /// <param name="value">The Value to be applied to the header X-Frame-Options header</param>
+        /// <param name="allowFromUrl">If ALLOW-FROM is selected, then this value is
+        /// required and must have sited that are permitted to frame your site.
+        /// Note: Chrome does not support the ALLOW-FROM option
+        /// Null by default</param>
+        public XFrameOptionsOptions(XFrameOptionsValues value, string allowFromUrl = null)
+        {
+            HeaderValue = value;
+
+            if (value == XFrameOptionsValues.AllowFrom && string.IsNullOrWhiteSpace(allowFromUrl))
+                throw new ArgumentException("ALLOW-FROM URL string cannot be empty when ALLOW-FROM option is selected.");
+            AllowFromUrl = allowFromUrl;
+        }
+
+        /// <summary>
+        /// Gets the predefined value to be applied to the header X-Frame-Options header.
+        /// DENY is set by default.
+        /// Note: Chrome does not support the ALLOW-FROM option
+        /// </summary>
+        public XFrameOptionsValues HeaderValue { get; set; } = XFrameOptionsValues.Deny;
+
+        /// <summary>
+        /// Gets the url allowed from a single domain.
+        /// Note: Chrome does not support the ALLOW-FROM option
+        /// </summary>
+        public string AllowFromUrl { get; set; }
+
+        public enum XFrameOptionsValues
+        {
+            [DefaultValue("DENY")]
+            Deny = 0,
+            [DefaultValue("SAMEORIGIN")]
+            SameOrigin = 1,
+            [DefaultValue("ALLOW-FROM")]
+            AllowFrom = 2,
+            [DefaultValue("ALLOWALL")]
+            AllowAll = 3
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XXssProtection/XXssProtectionExtensions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XXssProtection/XXssProtectionExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.XXssProtection
+{
+    internal static class XXssProtectionExtensions
+    {
+        public static string BuildHeaderValue(this XXssProtectionOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            var headerValue = options.EnableProtection ? "1" : "0";
+            if (options.EnableAttackBlock)
+            {
+                headerValue += "; mode=block";
+            }
+
+            return headerValue;
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XXssProtection/XXssProtectionMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XXssProtection/XXssProtectionMiddleware.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -18,8 +20,16 @@ namespace Joonasw.AspNetCore.SecurityHeaders.XXssProtection
 
         public async Task Invoke(HttpContext context)
         {
-            context.Response.Headers.Add(HeaderName, _headerValue);
+            if (!ContainsXXssProtectionHeader(context.Response))
+            {
+                context.Response.Headers.Add(HeaderName, _headerValue);
+            }
             await _next(context);
+        }
+
+        private static bool ContainsXXssProtectionHeader(HttpResponse response)
+        {
+            return response.Headers.Any(h => h.Key.Equals(HeaderName, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XXssProtection/XXssProtectionMiddleware.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XXssProtection/XXssProtectionMiddleware.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.XXssProtection
+{
+    public class XXssProtectionMiddleware
+    {
+        private const string HeaderName = "X-Xss-Protection";
+        private readonly RequestDelegate _next;
+        private readonly string _headerValue;
+
+        public XXssProtectionMiddleware(RequestDelegate next, IOptions<XXssProtectionOptions> options)
+        {
+            _next = next;
+            _headerValue = options.Value.BuildHeaderValue();
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            context.Response.Headers.Add(HeaderName, _headerValue);
+            await _next(context);
+        }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XXssProtection/XXssProtectionOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XXssProtection/XXssProtectionOptions.cs
@@ -2,6 +2,9 @@
 {
     public class XXssProtectionOptions
     {
+        /// <summary>
+        /// Defines the parameters for the X-Xss-Protection header with protection and block enabled
+        /// </summary>
         public XXssProtectionOptions()
         {
             

--- a/src/Joonasw.AspNetCore.SecurityHeaders/XXssProtection/XXssProtectionOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/XXssProtection/XXssProtectionOptions.cs
@@ -1,0 +1,33 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.XXssProtection
+{
+    public class XXssProtectionOptions
+    {
+        public XXssProtectionOptions()
+        {
+            
+        }
+
+        /// <summary>
+        /// Defines the parameters for the X-Xss-Protection header sent in response to clients
+        /// </summary>
+        /// <param name="enableProtection">Enable protection for this host</param>
+        /// <param name="enableAttackBlock">Block the response if it detects an attack rather than sanitising the script</param>
+        public XXssProtectionOptions(bool enableProtection, bool enableAttackBlock)
+        {
+            EnableProtection = enableProtection;
+            EnableAttackBlock = enableAttackBlock;
+        }
+
+        /// <summary>
+        /// Get the Enable Protection value for enabling or disabling Protection
+        /// Enabled by default.
+        /// </summary>
+        public bool EnableProtection { get; set; } = true;
+
+        /// <summary>
+        /// Gets the Enable Block value to block the response if it detects an attack rather than sanitising the script
+        /// Enabled by default.
+        /// </summary>
+        public bool EnableAttackBlock { get; set; } = true;
+    }
+}

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Samples/Startup.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Samples/Startup.cs
@@ -1,10 +1,12 @@
-﻿using Joonasw.AspNetCore.SecurityHeaders.Samples.Middleware;
+﻿using Joonasw.AspNetCore.SecurityHeaders.Csp;
+using Joonasw.AspNetCore.SecurityHeaders.Hpkp;
+using Joonasw.AspNetCore.SecurityHeaders.Hsts;
+using Joonasw.AspNetCore.SecurityHeaders.Samples.Middleware;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
 
 namespace Joonasw.AspNetCore.SecurityHeaders.Samples
 {
@@ -114,6 +116,75 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Samples
             //        context.ShouldNotSend = context.HttpContext.Request.Path.StartsWithSegments("/api");
             //        return Task.CompletedTask;
             //    };
+            //});
+
+            app.UseXFrameOptions();
+            // Manual Configuration
+            //app.UseXFrameOptions(new XFrameOptionsOptions(XFrameOptionsOptions.XFrameOptionsValues.Deny));
+
+            app.UseXXssProtection();
+            // Manual Configuration
+            //app.UseXXssProtection(new XXssProtectionOptions(false, false));
+
+            app.UseXContentTypeOptions();
+            // Manual Configuration
+            //app.UseXContentTypeOptions(new XContentTypeOptionsOptions(true));
+
+            app.UseReferrerPolicy();
+            // Manual Configuration
+            //app.UseReferrerPolicy(
+            //    new ReferrerPolicyOptions(ReferrerPolicyOptions.ReferrerPolicyValues.NoReferrerWhenDowngrade));
+
+            app.UseExpectCT();
+            // Manual Configuration
+            //app.UseExpectCT(
+            //    new ExpectCTOptions(TimeSpan.FromSeconds(30), "/expect-ct-report", true));
+
+            app.UseFeaturePolicy();
+            // Manual Configuration
+            //app.UseFeaturePolicy(fp =>
+            //{
+            //    fp.AllowGeolocation
+            //        .FromSelf()
+            //        .From("https://google.com");
+
+            //    fp.AllowMidi
+            //        .FromAnywhere();
+
+            //    fp.AllowNotifications
+            //        .FromSelf();
+
+            //    fp.AllowPush
+            //        .FromNowhere();
+
+            //    fp.AllowSyncXhr
+            //        .FromNowhere();
+
+            //    fp.AllowMicrophone
+            //        .FromAnywhere();
+
+            //    fp.AllowCamera
+            //        .FromNowhere();
+
+            //    fp.AllowMagnetometer
+            //        .FromSelf();
+
+            //    fp.AllowGyroscope
+            //        .FromSelf()
+            //        .From("https://google.com")
+            //        .From("https://www.yahoo.com");
+
+            //    fp.AllowSpeaker
+            //        .FromNowhere();
+
+            //    fp.AllowVibrate
+            //        .FromNowhere();
+
+            //    fp.AllowFullscreen
+            //        .FromSelf();
+
+            //    fp.AllowPayment.
+            //        FromNowhere();
             //});
 
             app.UseMvc(routes =>

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspOptionsTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspOptionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Joonasw.AspNetCore.SecurityHeaders.Csp;
 using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
 using Xunit;
 

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/XFrameOptionsTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/XFrameOptionsTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Joonasw.AspNetCore.SecurityHeaders.XFrameOptions;
+using Xunit;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.Tests
+{
+    public class XFrameOptionsTests
+    {
+        [Fact]
+        public void DenySetByDefault_ResultIsCorrect()
+        {
+            var options = new XFrameOptionsOptions();
+
+            Assert.Equal(XFrameOptionsOptions.XFrameOptionsValues.Deny, options.HeaderValue);
+        }
+
+        [Fact]
+        public void ValueSetIsMaintained_ResultIsCorrect()
+        {
+            const XFrameOptionsOptions.XFrameOptionsValues expected 
+                = XFrameOptionsOptions.XFrameOptionsValues.AllowAll;
+
+            var options = new XFrameOptionsOptions(expected);
+
+            Assert.Equal(expected, options.HeaderValue);
+        }
+
+        [Fact]
+        public void WhenSetAllowFromUrlIsRequired_ResultIsCorrect()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var options = new XFrameOptionsOptions(XFrameOptionsOptions.XFrameOptionsValues.AllowFrom);
+            });
+        }
+
+        [Fact]
+        public void WhenSetAllowFromUrlDoesNotThrow_ResultIsCorrect()
+        {
+            var options = Record.Exception(() => 
+                new XFrameOptionsOptions(XFrameOptionsOptions.XFrameOptionsValues.AllowFrom, "https://google.com"));
+
+            Assert.Null(options);
+        }
+    }
+}

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/XXssProtectionTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/XXssProtectionTests.cs
@@ -1,0 +1,26 @@
+﻿using Joonasw.AspNetCore.SecurityHeaders.XXssProtection;
+using Xunit;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.Tests
+{
+    public class XXssProtectionTests
+    {
+        [Fact]
+        public void EnabledAndBlockedByDefault_ResultIsCorrect()
+        {
+            var options = new XXssProtectionOptions();
+
+            Assert.True(options.EnableProtection);
+            Assert.True(options.EnableAttackBlock);
+        }
+
+        [Fact]
+        public void EnabledAndBlockedAreOffWhenSet_ResultIsCorrect()
+        {
+            var options = new XXssProtectionOptions(false, false);
+
+            Assert.False(options.EnableProtection);
+            Assert.False(options.EnableAttackBlock);
+        }
+    }
+}


### PR DESCRIPTION
Closes #28 

Adds ability to use all security headers, including upcoming headers from Chrome.