### PR TITLE
adding in changes for the nonce service

### DIFF
--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/CspNonceService.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/CspNonceService.cs
@@ -6,6 +6,12 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp
     public class CspNonceService : ICspNonceService
     {
         private readonly string _nonce;
+        private static char base64PadCharacter = '=';
+        private static string doubleBase64PadCharacter = "==";
+        private static char base64Character62 = '+';
+        private static char base64Character63 = '/';
+        private static char base64UrlCharacter62 = '-';
+        private static char _base64UrlCharacter63 = '_';
 
         public CspNonceService(int nonceByteAmount = 32)
         {
@@ -15,7 +21,15 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp
                 rng.GetBytes(nonceBytes);
             }
 
-            _nonce = Convert.ToBase64String(nonceBytes);
+          var s = Convert.ToBase64String(nonceBytes);
+          // a base64String can have elements that aren't URL friendly. In testing chrome appeared to ignore nonces that weren't URL friendly (or the tag helper did).
+          // the replacement code comes from Microsoft.IdentityModel.Tokens.Base64UrlEncoder
+          s = s.Split(base64PadCharacter)[0]; // Remove any trailing padding
+          s = s.Replace(base64Character62, base64UrlCharacter62);  // 62nd char of encoding
+          s = s.Replace(base64Character63, _base64UrlCharacter63);  // 63rd char of encoding
+
+          _nonce = s;
+            
         }
 
         public string GetNonce()

--- a/src/Joonasw.AspNetCore.SecurityHeaders/TagHelpers/NonceTagHelper.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/TagHelpers/NonceTagHelper.cs
@@ -26,7 +26,11 @@ namespace Joonasw.AspNetCore.SecurityHeaders.TagHelpers
             {
                 // The nonce service is created per request, so we
                 // get the same nonce here as the CSP header
-                output.Attributes.Add("nonce", _nonceService.GetNonce());
+                // when doing this, the nonce wasn't reliably being injected (that might have been due to the nonce have non url friendly chars). 
+                //output.Attributes.Add("nonce", _nonceService.GetNonce());
+                // this injected the nonce all the time.
+                var attribute = new TagHelperAttribute("nonce", _nonceService.GetNonce(), HtmlAttributeValueStyle.DoubleQuotes);
+                output.Attributes.SetAttribute(attribute);
             }
         }
     }

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspScriptsBuilderTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspScriptsBuilderTests.cs
@@ -6,7 +6,9 @@ using Xunit;
 
 namespace Joonasw.AspNetCore.SecurityHeaders.Tests
 {
-    public class CspScriptsBuilderTests
+  using Csp;
+
+  public class CspScriptsBuilderTests
     {
         [Fact]
         public void FromNowhere_SetsAllowNoneToTrue()
@@ -28,6 +30,24 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Tests
             CspScriptSrcOptions options = builder.BuildOptions();
 
             Assert.True(options.AllowSelf);
+        }
+
+        [Fact]
+        public void FromSelf_WithNonce_HasValue()
+        {
+          var nonceService = new CspNonceService(32);
+          var nonce = nonceService.GetNonce();
+      
+          var builder = new CspBuilder();
+          builder.AllowScripts.FromSelf().AddNonce();
+            
+          var headerValue = builder.BuildCspOptions().ToString(nonceService).headerValue;
+
+          Assert.DoesNotContain("+", nonce);
+          Assert.DoesNotContain("/", nonce);
+          Assert.DoesNotContain("=", nonce);
+      
+          Assert.Equal($"script-src 'self' 'nonce-{nonce}'", headerValue);
         }
 
         [Fact]


### PR DESCRIPTION
We were seeing this https://github.com/juunas11/aspnetcore-security-headers/issues/31#issuecomment-434029549 as well.

We tracked the issue down to either the tag helper or the nonce not being URL friendly (which doesn't make sense), but when we included both changes Razor started injecting the nonce correctly.