### PR TITLE
Add support for manifest-src CSP directive

### DIFF
--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
@@ -33,14 +33,14 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
         /// Set up rules for AJAX, WebSockets and EventSource.
         /// </summary>
         public CspConnectionBuilder AllowConnections { get; } = new CspConnectionBuilder();
-	    /// <summary>
-	    /// Sets up rules for where this app can load web manifests from
-	    /// </summary>
-	    public CspManifestBuilder AllowManifest { get; } = new CspManifestBuilder();
-		/// <summary>
-		/// Set up rules for fonts.
-		/// </summary>
-		public CspFontsBuilder AllowFonts { get; } = new CspFontsBuilder();
+        /// <summary>
+        /// Sets up rules for where this app can load web manifests from
+        /// </summary>
+        public CspManifestBuilder AllowManifest { get; } = new CspManifestBuilder();
+        /// <summary>
+        /// Set up rules for fonts.
+        /// </summary>
+        public CspFontsBuilder AllowFonts { get; } = new CspFontsBuilder();
         /// <summary>
         /// Set up rules for audio and video in e.g. HTML5 audio and video elements.
         /// </summary>
@@ -129,7 +129,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
             _options.Child = AllowChildren.BuildOptions();
 #pragma warning restore CS0618 // Type or member is obsolete
             _options.Connect = AllowConnections.BuildOptions();
-			_options.Manifest = AllowManifest.BuildOptions();
+            _options.Manifest = AllowManifest.BuildOptions();
             _options.Default = ByDefaultAllow.BuildOptions();
             _options.Font = AllowFonts.BuildOptions();
             _options.FormAction = AllowFormActions.BuildOptions();
@@ -142,8 +142,8 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
             _options.Sandbox = _sandboxBuilder.BuildOptions();
             _options.Frame = AllowFrames.BuildOptions();
             _options.Worker = AllowWorkers.BuildOptions();
-	        _options.Prefetch = AllowPrefetch.BuildOptions();
-			_options.BaseUri = AllowBaseUri.BuildOptions();
+            _options.Prefetch = AllowPrefetch.BuildOptions();
+            _options.BaseUri = AllowBaseUri.BuildOptions();
             _options.OnSendingHeader = OnSendingHeader;
             return _options;
         }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspBuilder.cs
@@ -33,10 +33,14 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
         /// Set up rules for AJAX, WebSockets and EventSource.
         /// </summary>
         public CspConnectionBuilder AllowConnections { get; } = new CspConnectionBuilder();
-        /// <summary>
-        /// Set up rules for fonts.
-        /// </summary>
-        public CspFontsBuilder AllowFonts { get; } = new CspFontsBuilder();
+	    /// <summary>
+	    /// Sets up rules for where this app can load web manifests from
+	    /// </summary>
+	    public CspManifestBuilder AllowManifest { get; } = new CspManifestBuilder();
+		/// <summary>
+		/// Set up rules for fonts.
+		/// </summary>
+		public CspFontsBuilder AllowFonts { get; } = new CspFontsBuilder();
         /// <summary>
         /// Set up rules for audio and video in e.g. HTML5 audio and video elements.
         /// </summary>
@@ -125,6 +129,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
             _options.Child = AllowChildren.BuildOptions();
 #pragma warning restore CS0618 // Type or member is obsolete
             _options.Connect = AllowConnections.BuildOptions();
+			_options.Manifest = AllowManifest.BuildOptions();
             _options.Default = ByDefaultAllow.BuildOptions();
             _options.Font = AllowFonts.BuildOptions();
             _options.FormAction = AllowFormActions.BuildOptions();

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspManifestBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspManifestBuilder.cs
@@ -1,0 +1,60 @@
+﻿using Joonasw.AspNetCore.SecurityHeaders.Csp.Options;
+
+namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
+{
+	/// <summary>
+	/// Builder for controlling where web manifests can be loaded from
+	/// </summary>
+    public class CspManifestBuilder {
+		private readonly CspManifestSrcOptions _options = new CspManifestSrcOptions();
+
+		/// <summary>
+		/// Allow manifests to be loaded from the current domain.
+		/// </summary>
+		/// <returns>The builder for call chaining</returns>
+		public CspManifestBuilder FromSelf() {
+			_options.AllowSelf = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Allow manifests to load from the given <paramref name="uri"/>.
+		/// </summary>
+		/// <param name="uri">The URI to allow.</param>
+		/// <returns>The builder for call chaining</returns>
+		public CspManifestBuilder From(string uri) {
+			_options.AllowedSources.Add(uri);
+			return this;
+		}
+
+		/// <summary>
+		/// Allow manifests to load from anywhere.
+		/// </summary>
+		/// <returns>The builder for call chaining</returns>
+		public CspManifestBuilder FromAnywhere() {
+			_options.AllowAny = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Block all loading of manifests.
+		/// </summary>
+		/// <returns>The builder for call chaining</returns>
+		public void FromNowhere() {
+			_options.AllowNone = true;
+		}
+
+		/// <summary>
+		/// Allow manifests to load from secure connections.
+		/// </summary>
+		/// <returns>The builder for call chaining</returns>
+		public CspManifestBuilder OnlyOverHttps() {
+			_options.AllowOnlyHttps = true;
+			return this;
+		}
+
+		public CspManifestSrcOptions BuildOptions() {
+			return _options;
+		}
+	}
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspManifestBuilder.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Builder/CspManifestBuilder.cs
@@ -2,59 +2,59 @@
 
 namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Builder
 {
-	/// <summary>
-	/// Builder for controlling where web manifests can be loaded from
-	/// </summary>
+    /// <summary>
+    /// Builder for controlling where web manifests can be loaded from
+    /// </summary>
     public class CspManifestBuilder {
-		private readonly CspManifestSrcOptions _options = new CspManifestSrcOptions();
+        private readonly CspManifestSrcOptions _options = new CspManifestSrcOptions();
 
-		/// <summary>
-		/// Allow manifests to be loaded from the current domain.
-		/// </summary>
-		/// <returns>The builder for call chaining</returns>
-		public CspManifestBuilder FromSelf() {
-			_options.AllowSelf = true;
-			return this;
-		}
+        /// <summary>
+        /// Allow manifests to be loaded from the current domain.
+        /// </summary>
+        /// <returns>The builder for call chaining</returns>
+        public CspManifestBuilder FromSelf() {
+            _options.AllowSelf = true;
+            return this;
+        }
 
-		/// <summary>
-		/// Allow manifests to load from the given <paramref name="uri"/>.
-		/// </summary>
-		/// <param name="uri">The URI to allow.</param>
-		/// <returns>The builder for call chaining</returns>
-		public CspManifestBuilder From(string uri) {
-			_options.AllowedSources.Add(uri);
-			return this;
-		}
+        /// <summary>
+        /// Allow manifests to load from the given <paramref name="uri"/>.
+        /// </summary>
+        /// <param name="uri">The URI to allow.</param>
+        /// <returns>The builder for call chaining</returns>
+        public CspManifestBuilder From(string uri) {
+            _options.AllowedSources.Add(uri);
+            return this;
+        }
 
-		/// <summary>
-		/// Allow manifests to load from anywhere.
-		/// </summary>
-		/// <returns>The builder for call chaining</returns>
-		public CspManifestBuilder FromAnywhere() {
-			_options.AllowAny = true;
-			return this;
-		}
+        /// <summary>
+        /// Allow manifests to load from anywhere.
+        /// </summary>
+        /// <returns>The builder for call chaining</returns>
+        public CspManifestBuilder FromAnywhere() {
+            _options.AllowAny = true;
+            return this;
+        }
 
-		/// <summary>
-		/// Block all loading of manifests.
-		/// </summary>
-		/// <returns>The builder for call chaining</returns>
-		public void FromNowhere() {
-			_options.AllowNone = true;
-		}
+        /// <summary>
+        /// Block all loading of manifests.
+        /// </summary>
+        /// <returns>The builder for call chaining</returns>
+        public void FromNowhere() {
+            _options.AllowNone = true;
+        }
 
-		/// <summary>
-		/// Allow manifests to load from secure connections.
-		/// </summary>
-		/// <returns>The builder for call chaining</returns>
-		public CspManifestBuilder OnlyOverHttps() {
-			_options.AllowOnlyHttps = true;
-			return this;
-		}
+        /// <summary>
+        /// Allow manifests to load from secure connections.
+        /// </summary>
+        /// <returns>The builder for call chaining</returns>
+        public CspManifestBuilder OnlyOverHttps() {
+            _options.AllowOnlyHttps = true;
+            return this;
+        }
 
-		public CspManifestSrcOptions BuildOptions() {
-			return _options;
-		}
-	}
+        public CspManifestSrcOptions BuildOptions() {
+            return _options;
+        }
+    }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Options/CspManifestSrcOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Options/CspManifestSrcOptions.cs
@@ -2,9 +2,9 @@
 {
     public class CspManifestSrcOptions : CspSrcOptionsBase
     {
-		public CspManifestSrcOptions()
-			:base ("manifest-src") 
-		{
-	    }
+        public CspManifestSrcOptions()
+            :base ("manifest-src") 
+        {
+        }
     }
 }

--- a/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Options/CspManifestSrcOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/Csp/Options/CspManifestSrcOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace Joonasw.AspNetCore.SecurityHeaders.Csp.Options
+{
+    public class CspManifestSrcOptions : CspSrcOptionsBase
+    {
+		public CspManifestSrcOptions()
+			:base ("manifest-src") 
+		{
+	    }
+    }
+}

--- a/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
@@ -37,6 +37,10 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         /// Rules to apply for AJAX, WebSockets and EventSource.
         /// </summary>
         public CspConnectSrcOptions Connect { get; set; }
+		/// <summary>
+		/// Rules to control where web manifests can be loaded from
+		/// </summary>
+		public CspManifestSrcOptions Manifest { get; set; }
         /// <summary>
         /// Rules to apply for fonts.
         /// </summary>
@@ -141,6 +145,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
             Child = new CspChildSrcOptions();
 #pragma warning restore CS0618 // Type or member is obsolete
             Connect = new CspConnectSrcOptions();
+			Manifest = new CspManifestSrcOptions();
             Font = new CspFontSrcOptions();
             FormAction = new CspFormActionOptions();
             Img = new CspImgSrcOptions();
@@ -176,6 +181,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
                 Child.ToString(nonceService),
 #pragma warning restore CS0618 // Type or member is obsolete
                 Connect.ToString(nonceService),
+				Manifest.ToString(nonceService),
                 Font.ToString(nonceService),
                 FormAction.ToString(nonceService),
                 Img.ToString(nonceService),

--- a/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
+++ b/src/Joonasw.AspNetCore.SecurityHeaders/CspOptions.cs
@@ -37,10 +37,10 @@ namespace Joonasw.AspNetCore.SecurityHeaders
         /// Rules to apply for AJAX, WebSockets and EventSource.
         /// </summary>
         public CspConnectSrcOptions Connect { get; set; }
-		/// <summary>
-		/// Rules to control where web manifests can be loaded from
-		/// </summary>
-		public CspManifestSrcOptions Manifest { get; set; }
+        /// <summary>
+        /// Rules to control where web manifests can be loaded from
+        /// </summary>
+        public CspManifestSrcOptions Manifest { get; set; }
         /// <summary>
         /// Rules to apply for fonts.
         /// </summary>
@@ -145,7 +145,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
             Child = new CspChildSrcOptions();
 #pragma warning restore CS0618 // Type or member is obsolete
             Connect = new CspConnectSrcOptions();
-			Manifest = new CspManifestSrcOptions();
+            Manifest = new CspManifestSrcOptions();
             Font = new CspFontSrcOptions();
             FormAction = new CspFormActionOptions();
             Img = new CspImgSrcOptions();
@@ -181,7 +181,7 @@ namespace Joonasw.AspNetCore.SecurityHeaders
                 Child.ToString(nonceService),
 #pragma warning restore CS0618 // Type or member is obsolete
                 Connect.ToString(nonceService),
-				Manifest.ToString(nonceService),
+                Manifest.ToString(nonceService),
                 Font.ToString(nonceService),
                 FormAction.ToString(nonceService),
                 Img.ToString(nonceService),

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
@@ -95,26 +95,26 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Tests
         [Fact]
         public void WithPrefetch_ReturnsCorrectHeader()
         {
-	        var builder = new CspBuilder();
+            var builder = new CspBuilder();
 
-	        builder.AllowPrefetch.From("https://www.google.com");
+            builder.AllowPrefetch.From("https://www.google.com");
 
-	        var headerValue = builder.BuildCspOptions().ToString(null).headerValue;
+            var headerValue = builder.BuildCspOptions().ToString(null).headerValue;
 
-	        Assert.Equal("prefetch-src https://www.google.com", headerValue);
+            Assert.Equal("prefetch-src https://www.google.com", headerValue);
         }
 
-		[Fact]
-		public void WithManifest_ReturnsCorrectHeader() 
-		{
-			var builder = new CspBuilder();
+        [Fact]
+        public void WithManifest_ReturnsCorrectHeader() 
+        {
+            var builder = new CspBuilder();
 
-			builder.AllowManifest.From("https://www.google.com");
+            builder.AllowManifest.From("https://www.google.com");
 
-			var headerValue = builder.BuildCspOptions().ToString(null).headerValue;
+            var headerValue = builder.BuildCspOptions().ToString(null).headerValue;
 
-			Assert.Equal("manifest-src https://www.google.com", headerValue);
-		}
+            Assert.Equal("manifest-src https://www.google.com", headerValue);
+        }
 
         [Fact]
         public async Task OnSendingHeader_ShouldNotSendTest()

--- a/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
+++ b/test/Joonasw.AspNetCore.SecurityHeaders.Tests/CspBuilderTests.cs
@@ -104,6 +104,18 @@ namespace Joonasw.AspNetCore.SecurityHeaders.Tests
 	        Assert.Equal("prefetch-src https://www.google.com", headerValue);
         }
 
+		[Fact]
+		public void WithManifest_ReturnsCorrectHeader() 
+		{
+			var builder = new CspBuilder();
+
+			builder.AllowManifest.From("https://www.google.com");
+
+			var headerValue = builder.BuildCspOptions().ToString(null).headerValue;
+
+			Assert.Equal("manifest-src https://www.google.com", headerValue);
+		}
+
         [Fact]
         public async Task OnSendingHeader_ShouldNotSendTest()
         {


### PR DESCRIPTION
Add support for the [`manifest-src`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/manifest-src) directive. This controls how web manifests can be loaded.